### PR TITLE
Replace first paragraph of Installing SLERT

### DIFF
--- a/xml/art_slert_quickstart.xml
+++ b/xml/art_slert_quickstart.xml
@@ -91,16 +91,10 @@
   
   <sect1 xml:id="sec.slert.quick.install">
     <title>Installing &slerte;</title>
-
-    <para> To install &slerte; &productnumber;, start a regular &sls;
-      &productnumber; installation. Select &slerte; &productnumber; as
-      an add-on product during the installation. Alternately, if &sls;
-      is already installed, you can start the Add-on Product
-      installation from &yast; or enable &slerte; in the &yast; &scc;
-      configuration. However, in the &yast; Boot Loader
-      configurator you need to manually select the <filename>-rt</filename> kernel
-      flavor as the default. </para>
-
+    <para>To install &slerte; &productnumber;, refer to the
+     &instquick; of &sls;&nbsp;&productnumber;
+     <link xlink:href="https://www.suse.com/documentation/sles-15/book_quickstarts/data/sec_sle_installquick.html"/>
+    </para>
     <para> &slerte; always needs a &sls; &productnumber; base, it cannot
       be installed in stand-alone mode. For information on how to
       install add-on products, see the &sle; &productnumber; &deploy;,


### PR DESCRIPTION
SLERT is not the add-on product anymore as in SLE12. Thus, we need to refer to the general installation of SLE15 SP1.

See the following output:

----

![slert-quickstart](https://user-images.githubusercontent.com/1312925/48894852-08586e00-ee44-11e8-83ff-baa3f4fa646a.png)
