### PR TITLE
Fix bsc#1125003 Correct SLE RT install section

### DIFF
--- a/xml/art_slert_quickstart.xml
+++ b/xml/art_slert_quickstart.xml
@@ -95,11 +95,10 @@
      &instquick; of &sls;&nbsp;&productnumber;
      <link xlink:href="https://www.suse.com/documentation/sles-15/book_quickstarts/data/sec_sle_installquick.html"/>
     </para>
-    <para> &slerte; always needs a &sls; &productnumber; base, it cannot
-      be installed in stand-alone mode. For information on how to
-      install add-on products, see the &sle; &productnumber; &deploy;,
-      available at <link xlink:href="http://www.suse.com/doc"/>. Refer
-      to chapter <citetitle>Installing Add-On Products</citetitle>. </para>
+    <para>The product requires the additional package DVD for installation as
+    described in &deploy;, chapter <citetitle>Extension and Module
+    Selection</citetitle> in section <citetitle>Selecting Extensions and
+    Modules without Registration</citetitle>. </para>
     <para> The following sections provide a brief introduction to the
       tools and possibilities of &slerte;. </para>
   </sect1>


### PR DESCRIPTION
This PR fixes bsc#1125003

SLE RT does NOT need SLES anymore. The RT product is a base product now (not a SLES addon anymore).

@JeffreyCheung if you have time it would be very nice if I get an thumbs up from you :wink: so I can merge it til Friday (I'm not in the office next week).