### PR TITLE
install quick start: Rename to "Setup Guide"

### DIFF
--- a/DC-SLE-RT-setup
+++ b/DC-SLE-RT-setup
@@ -2,7 +2,7 @@
 ## Quick Start
 
 MAIN=MAIN.SLERT.xml
-ROOTID=article-installation
+ROOTID=article-setup
 
 # Profiling
 PROFOS="slert"

--- a/xml/MAIN.SLERT.xml
+++ b/xml/MAIN.SLERT.xml
@@ -32,7 +32,7 @@
 
   <book xml:id="book-slert-qs">
     <title>Quick Start Manuals</title>
-    <xi:include href="article_installation.xml"/>
+    <xi:include href="article_setup.xml"/>
     <xi:include href="article_hardware_testing.xml"/>
     <xi:include href="article_virtualization.xml"/>
     <xi:include href="common_legal.xml"/>

--- a/xml/article_setup.xml
+++ b/xml/article_setup.xml
@@ -7,11 +7,11 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
 ]>
-<article version="5.0" xml:lang="en" xml:id="article-installation"
+<article version="5.0" xml:lang="en" xml:id="article-setup"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Quick Start</title>
+  <title>Setup Guide</title>
   <subtitle>&productname; &productnumber;</subtitle>
   <info>
     <productname>&productname;</productname>


### PR DESCRIPTION
We previously renamed the ID/file name of this guide to
article[-_]installation.* (2e7443c4). That is consistent with SLES,
SLED, etc., but it does not reflect the content as far as I can tell.
Which is:
* an overview of the product
* instructions for important initial settings

Now, I am not sure whether "Setup Guide" is the best description of
that but it seems better than "(Installation) Quick Start" when the
installation is not mentioned.