### PR TITLE
virt: Improve wording of Virtualization Guide abstract & bycatch

### DIFF
--- a/xml/MAIN.SLERT.xml
+++ b/xml/MAIN.SLERT.xml
@@ -31,7 +31,7 @@
   <xi:include href="book_slert_shielding.xml"/>
 
   <book xml:id="book-slert-qs">
-    <title>Quick Start Manuals</title>
+    <title>Quick Start Guides</title>
     <xi:include href="article_setup.xml"/>
     <xi:include href="article_hardware_testing.xml"/>
     <xi:include href="article_virtualization.xml"/>

--- a/xml/article_hardware_testing.xml
+++ b/xml/article_hardware_testing.xml
@@ -33,7 +33,7 @@
  </info>
 
  <sect1 xml:id="sec-hwtest-basics">
-  <title>General Testing Procedure and Analysis</title>
+  <title>General testing procedure and analysis</title>
 
   <para>
    The first task you need to do when evaluating hardware for real-time is
@@ -110,7 +110,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-hwtest-cyct">
-  <title>Determining Latencies with <command>cyclictest</command></title>
+  <title>Determining latencies with <command>cyclictest</command></title>
 
   <para>
    The <command>cyclictest</command> command is part of the real-time kernel
@@ -172,7 +172,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-hwtest-hwlat">
-  <title>Determining Latencies with the Hardware Latency Detector</title>
+  <title>Determining latencies with the hardware latency detector</title>
 
   <para>
    The <emphasis>hardware latency detector</emphasis>
@@ -309,7 +309,7 @@
  </sect1>
 
  <sect1 xml:id="sec-hwtest-more">
-  <title>For More Information</title>
+  <title>More information</title>
 
   <para>
    For more information on <command>cyclictest</command>, see <command>man 8

--- a/xml/article_setup.xml
+++ b/xml/article_setup.xml
@@ -29,7 +29,7 @@
   </info>
   
   <sect1 xml:id="sec-slert-quick-overview">
-   <title>Product Overview</title>
+   <title>Product overview</title>
    <para>
     If your business can respond more quickly to new information and changing
     market conditions, you have a distinct advantage over those that cannot.
@@ -39,7 +39,7 @@
     competitors.
    </para>
    <sect2 xml:id="sec-slert-quick-key-features">
-    <title>Key Features</title>
+    <title>Key features</title>
     <para>Some of the key features for &slert; are:</para>
     <itemizedlist>
      <listitem>
@@ -71,7 +71,7 @@
    </sect2>
    
    <sect2 xml:id="sec-slert-quick-scenarios">
-    <title>Specific Scenario</title>
+    <title>Specific scenario</title>
     <para>&productname; &productnumber; supports virtualization and Docker usage as a Technology Preview ( best-effort support ). Refer to <xref linkend="article-virtualization"/> for reference.
     </para>
    </sect2>
@@ -88,7 +88,7 @@
   </sect1>
 
   <sect1 xml:id="sec-slert-quick-cset">
-    <title>Managing CPU Sets with <command>cset</command></title>
+    <title>Managing CPU sets with <command>cset</command></title>
     <para> In some circumstances, it is beneficial to be able to run
       specific tasks only on defined CPUs. For this reason, the Linux
       kernel provides a feature called <emphasis>cpuset</emphasis>. 
@@ -111,7 +111,7 @@
     <screen><command>cset</command> help shield</screen>
 
    <sect2 xml:id="sec-slert-quick-settingup-cpushield-single">
-    <title>Setting Up a CPU Shield for a Single CPU</title>
+    <title>Setting up a CPU shield for a single CPU</title>
     <para> The command <command>cset</command> provides the high level
      functionality to set up and manipulate CPU Sets. An example for setting
      up a CPU shield is: </para>
@@ -123,7 +123,7 @@
    </sect2>
 
    <sect2 xml:id="sec-slert-quick-settingup-cpushield-multi">
-    <title>Setting up CPU Shields for Multiple CPUs</title>
+    <title>Setting up CPU shields for multiple CPUs</title>
     <para>
      If you need to shield more than one CPUs, the argument of the
      <option>--cpu</option> option accepts comma separated lists of CPUs
@@ -154,7 +154,7 @@
    </sect2>
 
    <sect2 xml:id="sec-slert-quick-showing-cpu-shields">
-    <title>Showing CPU Shields</title>
+    <title>Showing CPU shields</title>
     <para>
      After the CPU shielding is set up you can display the current
       configuration by running <command>cset shield</command> without
@@ -188,7 +188,7 @@ cset: "user" cpuset of:  3-7 cpu,  with: 0
    </sect2>
 
    <sect2 xml:id="sec-slert-quick-shielding-processes">
-    <title>Shielding Processes</title>
+    <title>Shielding processes</title>
     <para>
      Certain processes or groups of processes can be assigned to a
      shielded &cpuset;, after the CPU set is created. To start a new
@@ -227,7 +227,7 @@ cset: "user" cpuset of:  3-7 cpu,  with: 0
    </sect2>
    
    <sect2 xml:id="sec-slert-quick-showing-shielded-processes">
-    <title>Showing Shielded Processes</title>
+    <title>Showing shielded processes</title>
     <para> Use the <command>cset shield</command> command to show the
       number of currently shielded processes (the same command can be
       used to show the current CPU shield setup). To list shielded and
@@ -250,7 +250,7 @@ cset: "user" cpuset of:    3 cpu, with: 1
    </sect2>
 
    <sect2 xml:id="sec-slert-quick-unshielding-processes">
-    <title>Unshielding Processes</title>
+    <title>Unshielding processes</title>
     <para>
      To remove a process (or group of processes) from the CPU shield use the
      <option>--unshield</option> option. The argument for
@@ -265,7 +265,7 @@ cset: "user" cpuset of:    3 cpu, with: 1
    </sect2>
 
    <sect2 xml:id="sec-slert-quick-resetting-cpusets">
-    <title>Resetting CPU Sets</title>
+    <title>Resetting CPU sets</title>
     <para>
      To delete CPU sets use the <command>cset</command> option
      <option>--reset</option>. This will unshield all CPUs and
@@ -275,7 +275,7 @@ cset: "user" cpuset of:    3 cpu, with: 1
  </sect1>
 
  <sect1 xml:id="sec-slert-csets-tree">
-  <title>Managing Tree-like Structures with <command>cset</command></title>
+  <title>Managing tree-like structures with <command>cset</command></title>
 
     <!-- basic cset commands -->
 
@@ -495,7 +495,7 @@ cset: "user" cpuset of:    3 cpu, with: 1
   <!--
  
   <sect1>
-  <title>Executing Processes with <command>run</command></title>
+  <title>Executing processes with <command>run</command></title>
 
   <para>
    The command <command>run</command> creates an environment
@@ -822,7 +822,7 @@ cset: "user" cpuset of:    3 cpu, with: 1
   </sect1>-->
   <!--
  <sect1>
-  <title>Using CPU Sets</title>
+  <title>Using CPU sets</title>
   <para>
    In some circumstances, it is beneficial to be able to run specific
    tasks only on defined CPUs. For this reason, the linux kernel
@@ -981,7 +981,7 @@ mem_exclusive  memory_pressure_enabled  mems</screen>
   </para>
   <variablelist>
    <varlistentry>
-    <term>Create a Cpuset</term>
+    <term>Create a cpuset</term>
     <listitem>
      <para> 
       To create a cpuset with the name <literal>exampleset</literal>, just
@@ -991,7 +991,7 @@ mem_exclusive  memory_pressure_enabled  mems</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Remove a Cpuset</term>
+    <term>Remove a cpuset</term>
     <listitem>
      <para> To remove a cpuset, you only need to remove the cpuset directory.
       For example, use <command>rmdir /dev/cpuset/exampleset</command> to
@@ -1007,7 +1007,7 @@ mem_exclusive  memory_pressure_enabled  mems</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Add CPUs to a Cpuset</term>
+    <term>Add CPUs to a cpuset</term>
     <listitem>
      <para>
       To add CPUs to a set, you may either specify a comma separated
@@ -1021,7 +1021,7 @@ mem_exclusive  memory_pressure_enabled  mems</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Add Memory to a Cpuset</term>
+    <term>Add memory to a cpuset</term>
     <listitem>
      <para>
       You cannot move tasks to a cpuset without giving the cpuset
@@ -1032,7 +1032,7 @@ mem_exclusive  memory_pressure_enabled  mems</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Moving Tasks to Cpusets</term>
+    <term>Moving tasks to cpusets</term>
     <listitem>
      <para>
       A cpuset is just a useless structure, unless it handles some
@@ -1067,7 +1067,7 @@ echo $pid > tasks; done</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Automatically Remove Unused Cpusets</term>
+    <term>Automatically remove unused cpusets</term>
     <listitem>
      <para> In case a cpuset is not used any longer by any process, you might
       want to clean up such unused cpusets automatically. To initialize the
@@ -1088,7 +1088,7 @@ rmdir /dev/cpuset/$1
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Determine the Cpuset of a Specific Process</term>
+    <term>Determine the cpuset of a specific process</term>
     <listitem>
      <para>
       All processes with the process id <literal>PID</literal> have an entry
@@ -1103,7 +1103,7 @@ rmdir /dev/cpuset/$1
  </sect1>
  -->
   <sect1 xml:id="sec-quick-taskset">
-    <title>Specifying a CPU Affinity with <command>taskset</command></title>
+    <title>Specifying a CPU affinity with <command>taskset</command></title>
 
     <para> The default behavior of the kernel is to keep a process
       running on the same CPU if the system load is balanced over the
@@ -1203,7 +1203,7 @@ rmdir /dev/cpuset/$1
   </sect1>
 
   <sect1 xml:id="sec-quick-ionice">
-    <title>Changing I/O Priorities with <command>ionice</command></title>
+    <title>Changing I/O priorities with <command>ionice</command></title>
     <para> Handling I/O is one of the critical issues for all
       high-performance systems. If a task has lots of CPU power
       available, but must wait for the disk, it will not work as
@@ -1213,7 +1213,7 @@ rmdir /dev/cpuset/$1
 
     <variablelist>
       <varlistentry>
-        <term>The <emphasis>Best Effort</emphasis> Scheduler</term>
+        <term>The <emphasis>Best Effort</emphasis> scheduler</term>
         <listitem>
           <para> The <emphasis>Best Effort</emphasis> scheduler is the
             default I/O scheduler, and is used for all processes that do
@@ -1227,7 +1227,7 @@ rmdir /dev/cpuset/$1
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>The <emphasis>Real Time</emphasis> Scheduler</term>
+        <term>The <emphasis>Real Time</emphasis> scheduler</term>
         <listitem>
           <para> The real-time I/O class always gets the highest
             priority for disk access. The other schedulers will only be
@@ -1240,7 +1240,7 @@ rmdir /dev/cpuset/$1
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>The <emphasis>Idle</emphasis> Scheduler</term>
+        <term>The <emphasis>Idle</emphasis> scheduler</term>
         <listitem>
           <para> The <emphasis>Idle</emphasis> scheduler does not define
             any nice levels. I/O is only done in this class if no other
@@ -1299,7 +1299,7 @@ rmdir /dev/cpuset/$1
       page with <command>man 1 ionice</command></para>
   </sect1>
   <sect1 xml:id="sec-quick-io-block-change">
-    <title>Changing the I/O Scheduler for Block Devices</title>
+    <title>Changing the I/O scheduler for block devices</title>
 
     <para> The Linux kernel provides several block device schedulers
       that can be selected individually for each block device. All but
@@ -1310,7 +1310,7 @@ rmdir /dev/cpuset/$1
         <literal>noop</literal> scheduler. </para>
 
     <variablelist>
-      <title>The Linux I/O Schedulers</title>
+      <title>The Linux I/O schedulers</title>
       <varlistentry>
         <term>noop</term>
         <listitem>
@@ -1387,7 +1387,7 @@ noop deadline [cfq]</screen>
       system, use a similar approach. </para>
   </sect1>
   <sect1 xml:id="sec-quick-io-block-tune">
-    <title>Tuning the Block Device I/O Scheduler</title>
+    <title>Tuning the block device I/O scheduler</title>
 
     <para> All schedulers, except for the <emphasis>noop</emphasis>
       scheduler, have several common parameters that may be tuned for
@@ -1403,7 +1403,7 @@ noop deadline [cfq]</screen>
 
     <variablelist>
       <varlistentry>
-        <term>Anticipatory Scheduler</term>
+        <term>Anticipatory scheduler</term>
         <listitem>
           <variablelist>
             <varlistentry>
@@ -1429,7 +1429,7 @@ noop deadline [cfq]</screen>
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term>Deadline Scheduler</term>
+        <term>Deadline scheduler</term>
         <listitem>
           <variablelist>
             <varlistentry>
@@ -1591,7 +1591,7 @@ noop deadline [cfq]</screen>
   </sect1>
   <!--
  <sect1>
-  <title>Interrupt Priorities</title>
+  <title>Interrupt priorities</title>
 
   <para>
     
@@ -1603,7 +1603,7 @@ noop deadline [cfq]</screen>
  </sect1>
  -->
   <sect1 xml:id="sec-quick-more">
-    <title>For More Information</title>
+    <title>More information</title>
 
     <para> A lot of information about real-time implementations and
       administration can be found on the Internet. The following list

--- a/xml/article_setup.xml
+++ b/xml/article_setup.xml
@@ -72,7 +72,10 @@
    
    <sect2 xml:id="sec-slert-quick-scenarios">
     <title>Specific scenario</title>
-    <para>&productname; &productnumber; supports virtualization and Docker usage as a Technology Preview ( best-effort support ). Refer to <xref linkend="article-virtualization"/> for reference.
+    <para>
+     &productname; &productnumber; supports virtualization and Docker
+     usage as a Technology Preview (best-effort support). For reference,
+     see <xref linkend="article-virtualization"/>.
     </para>
    </sect2>
   </sect1>
@@ -229,8 +232,8 @@ cset: "user" cpuset of:  3-7 cpu,  with: 0
    <sect2 xml:id="sec-slert-quick-showing-shielded-processes">
     <title>Showing shielded processes</title>
     <para> Use the <command>cset shield</command> command to show the
-      number of currently shielded processes (the same command can be
-      used to show the current CPU shield setup). To list shielded and
+      number of currently shielded processes. (The same command can be
+      used to show the current CPU shield setup.) To list shielded and
       unshielded processes, add the <command>--verbose</command>
       option: </para>
 

--- a/xml/article_virtualization.xml
+++ b/xml/article_virtualization.xml
@@ -224,7 +224,7 @@
     <itemizedlist>
      <title>Docker Prerequisites</title>
      <listitem>
-      <para>kernel must be booted with <option>nortsched</option> commandline parameter</para>
+      <para>kernel must be booted with <option>nortsched</option> command-line parameter</para>
       <para>
        This is to hide cgroup scheduling from Docker. If cgroup scheduling
        is required then isolating docker is very problematic.</para>

--- a/xml/article_virtualization.xml
+++ b/xml/article_virtualization.xml
@@ -43,7 +43,7 @@
   </info>
 
   <sect1 xml:id="sec-virtguide-rtapp">
-   <title>Running RT Applications with non-RT &kvm; Guests</title>
+   <title>Running RT applications with non-RT &kvm; guests</title>
    <para>It is possible to achieve isolation of real-time workloads running
     alongside &kvm; by using standard methods. For example, cpusets and routing
     IRQs to dedicated CPUs, all of which can be achieved by using the cset
@@ -182,7 +182,7 @@
   </sect1>
 
   <sect1 xml:id="sec-virtguide-docker">
-   <title>RT Applications within Docker Feasibility</title>
+   <title>Running real-time applications within Docker</title>
    <para> It is important to note that real-time processes will be affected by
    container activity as there is insufficient isolation to guarantee zero
    cross-talk. There are no special settings, nor container-specific
@@ -212,7 +212,7 @@
    </procedure>
    
    <sect2 xml:id="sec-virtguide-docker-rt-env">
-    <title>Running Real-Time Applications in a Virtualized Environment</title>
+    <title>Running real-time applications in a virtualized environment</title>
     <para>
      Standard real-time dangers apply in that if the intention is to run a
      compute intensive application with realtime priority, then the user must
@@ -253,10 +253,10 @@
    </sect2>
 
    <sect2 xml:id="sec-virtguide-docker-shielding">
-    <title>Docker Shielding</title>
+    <title>Docker shielding</title>
     <para>There is currently no facility withing Docker to launch a container directly into an isolated cpuset, this must be done manually.</para>
     <example>
-     <title>Pseudo Script</title>
+     <title>Pseudo script</title>
      <screen language="bash"># note cpuset mount point
 cpuset_mnt=$(mount|grep cpuset|cut -d' ' -f3)
 
@@ -288,7 +288,7 @@ cset shield --userset=rtcpus --cpu=4-7 --reset</screen>
    <sect2 xml:id="sec-virtguide-docker-scripts">
     <title>Scripts</title>
     <example>
-     <title>Sample Shield Script</title>
+     <title>Sample shield script</title>
      <screen language="bash">#!/bin/sh
 
 let START_CPU=4
@@ -481,7 +481,7 @@ fi</screen>
     </example>
 
     <example>
-     <title>Patch to sysjitter to Use the User Affinity Instead of Whole Box</title>
+     <title>Patch to <literal>sysjitter</literal> to use the user affinity instead of whole box</title>
      <screen language="diff">sysjitter.c |   10 +++++++---
  1 file changed, 7 insertions(+), 3 deletions(-)
 
@@ -525,11 +525,11 @@ fi</screen>
   </sect1>
 
  <sect1 xml:id="sec-virtguide-rtkvmguests">
-  <title>Running RT Applications with RT &kvm; Guests</title>
+  <title>Running RT applications with RT &kvm; guests</title>
   <para>
    In <xref linkend="sec-virtguide-rtapp"/>, we see that it is possible
    to isolate real-time workloads running alongside &kvm;
-   by using standard methods. In &slea;15 RT SP2 this can be done in user space 
+   by using standard methods. In &slea; RT 15 SP2 this can be done in user space 
    using libvirt/qemu.
   </para>
   <para>
@@ -539,7 +539,7 @@ fi</screen>
    Then the host kernel treats the guest I/Os like any user-space application.
   </para>
   <para>
-   In &slea;15 SP3, both &qemu; and libvirt support isolating the CPUs, 
+   In &slea; RT 15 SP3, both &qemu; and libvirt support isolating the CPUs, 
    partitioning the memory for guests, and setting the vCPU/iothread scheduler 
    policy and priority for running both non-RT &kvm; and RT &kvm;.
   </para>
@@ -561,14 +561,14 @@ fi</screen>
      </para>
      <variablelist>
       <varlistentry>
-       <term>CPU Allocation</term>
+       <term>CPU allocation</term>
        <listitem>
         <para>We can define the maximum number of virtual CPUs allocated for
          the guest OS.</para>
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>CPU Tuning</term>
+       <term>CPU tuning</term>
        <listitem>
         <itemizedlist>
          <listitem>
@@ -591,7 +591,7 @@ fi</screen>
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Memory Backing</term>
+       <term>Memory backing</term>
        <listitem>
         <para>
          Use memory backing to allocate enough memory in the guest to avoid 
@@ -626,11 +626,11 @@ fi</screen>
 </domain>]]></screen>
   </sect2>
   <sect2 xml:id="sec-virtguide-rtkvmguests-othersettings">
-   <title>Other Host Settings</title>
+   <title>Other host settings</title>
    <orderedlist>
     <listitem>
      <formalpara>
-      <title>Power Management</title>
+      <title>Power management</title>
       <para>Intel processors have a power management feature that puts the system
        into power-saving mode when the system is under-utilized. The system 
        should be configured for maximum performance, rather than allowing 
@@ -651,7 +651,7 @@ fi</screen>
     </listitem>
     <listitem>
      <formalpara>
-      <title>Disable Interrupt Balancing (irqbalance)</title>
+      <title>Disable interrupt balancing (irqbalance)</title>
       <para>The irqbalance daemon is enabled by default. It distributes hardware 
        interrupts across CPUs in a multi-core system to increase performance. 
        When irqbalance is disabled, all interrupts will be handled by cpu0, 
@@ -661,7 +661,7 @@ fi</screen>
     </listitem>
     <listitem>
      <formalpara>
-      <title>RT Throttling</title>
+      <title>RT throttling</title>
       <para>The default values for the realtime throttling mechanism allocate
        95% of the CPU time to realtime tasks, and the remaining 5% to 
        non-realtime tasks. If RT throttling is disabled, realtime tasks may use 

--- a/xml/article_virtualization.xml
+++ b/xml/article_virtualization.xml
@@ -19,14 +19,26 @@
    <productnumber>&productnumber;</productnumber>
    <date><?dbtimestamp?></date>
    <abstract>
-      <para>&productname; &productnumber; supports virtualization and Docker usage as a Technology Preview ( best-effort support ). </para>
-
-<para>Keep in minds that each RT application would have to be individually accessed to see what degree of interference it experiences when running within a particular KVM configuration versus running on bare metal metal configuration. We 
-do not give any specific guarantees on performance or deadlines been missed.</para>
-
-<para>Generally speaking, one would expect it to be worse because some virtualisation overhead is inevitable but have no rule of thumb on how much worse it is. It's up to each RT application developer to set the performance and deadline requirements and evaluate if those requirements are met.</para>
-   
-<para>This guide provides the following 3 examples for user reference only.</para>
+    <para>
+     &productname; &productnumber; supports virtualization and Docker usage
+     as a technology preview only (best-effort support).
+    </para>
+    <para>
+     To see the degree of interference from running within a particular &kvm;
+     configuration versus running on bare-metal configuration, Each RT
+     application has to be assessed individually.
+     We do not give any specific guarantees on performance or deadlines been
+     missed.
+    </para>
+    <para>
+     Virtualization inevitably introduces overhead but there is currently no
+     rule of thumb for the performance penalty incurred.
+     It is up to each RT application developer to set performance and
+     deadline requirements and evaluate if those requirements are met.
+    </para>
+    <para>
+     This guide provides the following 3 examples for user reference only.
+    </para>
    </abstract>
   </info>
 

--- a/xml/common_copyright_quick.xml
+++ b/xml/common_copyright_quick.xml
@@ -5,7 +5,7 @@
   %entities;
 ]>
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0">
- <title>Legal Notice</title>
+ <title>Legal notice</title>
 
  <para>
   Copyright&copy; 2006&ndash;<?dbtimestamp format="Y"?>

--- a/xml/slert_cpuset_manipulation.xml
+++ b/xml/slert_cpuset_manipulation.xml
@@ -302,7 +302,7 @@ alext    16165     1 Soth beagled /usr/lib64/beagle/BeagleDaemon.exe --bg --auto
    <title>Execing Tasks with <literal>proc</literal></title>
    <para>
     To exec a task into a cpuset, the <command>proc</command> subcommand
-    needs to be employed with the <option>-e/--exec</option> option. Let’s
+    needs to be employed with the <option>-e/--exec</option> option. Let us
     exec a shell into the cpuset named <literal>two</literal> in our set.
     First we check to see what is running that set:
    </para>
@@ -327,7 +327,7 @@ root     20981 20955 Roth python ./cset proc -l two</screen>
     cpuset property of a running task is inherited by all its children.
     Since we executed the listing command from the new shell which was bound
     to cpuset two, the resulting process for the listing is also bound to
-    cpuset <literal>two</literal>. Let’s test that by running a new
+    cpuset <literal>two</literal>. Let us test that by running a new
     shell with no prefixed <command>cset</command> command.
    </para>
 <screen>&prompt.user;<command>bash</command>
@@ -619,7 +619,7 @@ cset: done</screen>
     <para>
      Note that only 70 actual kernel threads were moved and 76 were not. The
      reason that 76 kernel threads were not moved was because they are bound
-     to specific CPUs. Now, let’s move those kernel threads back to
+     to specific CPUs. Now, let us move those kernel threads back to
      <literal>root</literal>.
     </para>
 <screen>&prompt.user;<command>cset</command> proc -k -f two -t root
@@ -636,7 +636,7 @@ two          2 n          0 n       70    0    /two</screen>
     <para>
      <command>cset</command> refused to move the kernel threads back to
      <literal>root</literal> because it says that they are
-     <quote>bound</quote>. Let’s check this with the
+     <quote>bound</quote>. Let us check this with the
      <command>taskset</command> command.
     </para>
 <screen>&prompt.user;<command>cset</command> proc -l -s two | head -5
@@ -676,7 +676,7 @@ cset: done</screen>
    <title>Destroying Tasks</title>
    <para>
     There actually is no <command>cset</command> subcommand or option to
-    destroy tasks—it’s not really needed. Tasks exist and are accessible
+    destroy tasks—it is not really needed. Tasks exist and are accessible
     on the system as normal, even if they happen to be running in one cpuset
     or another. To destroy tasks, use the usual
     <keycombo><keycap function="control"/> <keycap>C</keycap></keycombo>
@@ -719,7 +719,7 @@ cset: done</screen>
 
   <para>
    You start first by creating the <literal>system</literal> and
-   <literal>user</literal> cpusets as follows. Let's assume that the machine
+   <literal>user</literal> cpusets as follows. Let us assume that the machine
    is a four-CPU machine without NUMA memory features. The system cpuset
    should hold only CPU0 while the user cpuset should hold the rest of the
    CPUs.

--- a/xml/slert_cpuset_manipulation.xml
+++ b/xml/slert_cpuset_manipulation.xml
@@ -5,7 +5,7 @@
   %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-cpuset">
- <title>Full Featured Cpuset Manipulation Commands</title>
+ <title>Full-featured cpuset manipulation commands</title>
  <para>
   While basic shielding as described above is useful and a common use model
   for <command>cset</command>, there comes a time when more functionality
@@ -15,7 +15,7 @@
   allows you to manipulate processes within those cpusets.
  </para>
  <sect1 xml:id="sec-shielding-cpuset-set">
-  <title>The set Subcommand</title>
+  <title>The set subcommand</title>
 
   <para>
    To do anything with cpusets, you must be able to create, adjust,
@@ -24,7 +24,7 @@
   </para>
 
   <sect2 xml:id="sec-shielding-cpuset-set-create-destroy">
-   <title>Creating and Destroying Cpusets with <command>set</command></title>
+   <title>Creating and destroying cpusets with <command>set</command></title>
    <para>
     The basic syntax of <command>set</command> for cpuset creation is:
    </para>
@@ -80,7 +80,7 @@ cset: done</screen>
     destroy.
    </para>
    <note>
-    <title>Information About the Mounted Cpuset File System</title>
+    <title>Information about the mounted cpuset file system</title>
     <para>
      The <command>cset</command> subcommand creates the cpusets based on a
      mounted cpuset file system. You do not need to know where that file
@@ -132,7 +132,7 @@ cset: --> modified cpuset "sub_set</screen>
   </sect2>
 
   <sect2 xml:id="sec-shielding-cpuset-set-list">
-   <title>Listing Cpusets with set</title>
+   <title>Listing cpusets with set</title>
    <para>
     To list cpusets, use the <command>set</command> subcommand with the
     <option>-l/--list</option> option. For example:
@@ -186,7 +186,7 @@ three        3 n          0 n       0     0    /one/two/three</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-shielding-cpuset-proc">
-  <title>The <command>proc</command> Subcommand</title>
+  <title>The <command>proc</command> subcommand</title>
 
   <para>
    Now that you know how to create, rename and destroy cpusets with the
@@ -207,7 +207,7 @@ two          2 n          0 n       3     0    /two
 three        3 n          0 n       10    0    /three</screen>
 
   <sect2 xml:id="sec-shielding-cpuset-proc-list">
-   <title>Listing Tasks With <command>proc</command></title>
+   <title>Listing tasks with <command>proc</command></title>
    <para>
     Operation of the <command>proc</command> subcommand follows the same
     model as the <command>set</command> subcommand. For example, to list
@@ -299,7 +299,7 @@ alext    16165     1 Soth beagled /usr/lib64/beagle/BeagleDaemon.exe --bg --auto
   </sect2>
 
   <sect2 xml:id="sec-shielding-cpuset-proc-exec">
-   <title>Execing Tasks with <literal>proc</literal></title>
+   <title>Execing tasks with <literal>proc</literal></title>
    <para>
     To exec a task into a cpuset, the <command>proc</command> subcommand
     needs to be employed with the <option>-e/--exec</option> option. Let us
@@ -381,7 +381,7 @@ cset: **> [Errno 2] No such file or directory</screen>
   </sect2>
 
   <sect2 xml:id="sec-shielding-cpuset-proc-move">
-   <title>Moving Tasks with <command>proc</command></title>
+   <title>Moving tasks with <command>proc</command></title>
    <para>
     Although the ability to exec a task into a cpuset is fundamental, you
     will most likely be moving tasks between cpusets more often. Moving
@@ -430,7 +430,7 @@ cset: **> [Errno 2] No such file or directory</screen>
     </varlistentry>
    </variablelist>
    <note>
-    <title>Information About the Range In a PIDSPEC</title>
+    <title>Information about the range in a PIDSPEC</title>
     <para>
      A range in a PIDSPEC does not need to have running tasks for every
      number in that range. In fact, it is not even an error if there are no
@@ -527,7 +527,7 @@ Name         CPUs-X       MEMs-X    Tasks Subs Path
 two          2 n          0 n       10    0    /two
 three        3 n          0 n       0     0    /three</screen>
    <sect3 xml:id="sec-shielding-cpuset-proc-move-taskset">
-    <title>Moving All Tasks From One Cpuset to Another</title>
+    <title>Moving all tasks from one cpuset to another</title>
     <para>
      There is a special case for moving all tasks currently running in one
      cpuset to another. This can be a common use case, and when you need to
@@ -571,7 +571,7 @@ two          2 n          0 n       0     0    /two
 three        3 n          0 n       10    0    /three</screen>
    </sect3>
    <sect3 xml:id="sec-shielding-cpuset-proc-move-threads">
-    <title>Moving Kernel Threads With <command>proc</command></title>
+    <title>Moving kernel threads with <command>proc</command></title>
     <para>
      Kernel threads are special and <command>cset</command> detects tasks
      that are kernel threads and will refuse to move them unless you also
@@ -592,7 +592,7 @@ three        3 n          0 n       10    0    /three</screen>
      option.
     </para>
     <warning>
-     <title>Use <option>--force</option> With Care</title>
+     <title>Use <option>--force</option> with care</title>
      <para>
       Overriding a task move command with <option>--force</option> can have
       dire consequences for the system. Be sure of the command before you
@@ -673,7 +673,7 @@ cset: done</screen>
   </sect2>
 
   <sect2 xml:id="sec-shielding-cpuset-proc-destroy">
-   <title>Destroying Tasks</title>
+   <title>Destroying tasks</title>
    <para>
     There actually is no <command>cset</command> subcommand or option to
     destroy tasks—it is not really needed. Tasks exist and are accessible
@@ -685,7 +685,7 @@ cset: done</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-shielding-cpuset-shielding-set-proc">
-  <title>Implementing <quote>Shielding</quote> With <command>set</command> and <command>proc</command></title>
+  <title>Implementing shielding with <command>set</command> and <command>proc</command></title>
 
   <para>
    With the preceding material on the <command>set</command> and
@@ -797,7 +797,7 @@ system       0 n          0 n       257   0    /system</screen>
   </para>
  </sect1>
  <sect1 xml:id="sec-shielding-cpuset-hierarchy-set-proc">
-  <title>Implementing Hierarchy With set and proc</title>
+  <title>Implementing hierarchy with set and proc</title>
 
   <para>
    One popular extended <emphasis>shielding</emphasis> model is based on
@@ -828,7 +828,7 @@ system       0 n          0 n       257   0    /system</screen>
   </para>
 
   <note>
-   <title>The Sense Behind Creating a prio_all Cpuset With All CPUs</title>
+   <title>The sense behind creating a prio_all cpuset with all CPUs</title>
    <para>
     You may ask, why create a <literal>prio_all</literal> with all CPUs when
     that is substantially the definition of the <literal>root</literal>
@@ -910,7 +910,7 @@ prio_med     2-3 n        0 n       0     1    /prio_all/prio_high/prio_med
 prio_low     3 n          0 n       0     0    /prio_all/pr...rio_med/prio_low</screen>
 
   <note>
-   <title>Why <option>-r/--recurse</option> Is Needed in This Case</title>
+   <title>Why <option>-r/--recurse</option> is needed in this case</title>
    <para>
     The option <option>-r</option>/<option>--recurse</option> lists all the
     sets in the last command above. If you execute that command without

--- a/xml/slert_gettinghelp.xml
+++ b/xml/slert_gettinghelp.xml
@@ -5,7 +5,7 @@
   %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shieldingt-help">
- <title>What to Do If There Are Problems</title>
+ <title>What to do if there are problems</title>
  <info/>
  <para>
   If you encounter any issues with the <command>cset</command> application,

--- a/xml/slert_intro.xml
+++ b/xml/slert_intro.xml
@@ -48,7 +48,7 @@
   <command>proc</command> subcommands.
  </para>
  <variablelist>
-  <title>Obtaining Online Help</title>
+  <title>Obtaining online help</title>
   <varlistentry>
    <term>For a full list of cset subcommands</term>
    <listitem>

--- a/xml/slert_shielding_model.xml
+++ b/xml/slert_shielding_model.xml
@@ -77,8 +77,8 @@
 
  <sect1 xml:id="sec-shielding-model-ex">
   <title>A simple shielding example</title>
-  <para> Assume that we have a 4-core machine that has uniform memory access.
-   This means there are 4 CPUs at your disposal and there is only one memory node
+  <para> Assume that we have a four-core machine that has uniform memory access.
+   This means there are four CPUs at your disposal and there is only one memory node
    available. On such machines, we do not need to specify any memory node
    parameters to cset, it sets up the only available memory node by default. </para>
 
@@ -103,7 +103,7 @@
  <sect1 xml:id="sec-shielding-model-ex-setup-teardown">
    <title>Setup and teardown of the shield</title>
    <para>
-    To set up a shield of 3 CPUs with 1 CPU left for low priority system
+    To set up a shield of three CPUs with one CPU left for low priority system
     processing, issue the following command.
    </para>
 <screen>&prompt.user;<command>cset</command> shield -c 1-3

--- a/xml/slert_shielding_model.xml
+++ b/xml/slert_shielding_model.xml
@@ -8,7 +8,7 @@
 <chapter version="5.0" xml:id="cha-shielding-model"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>The Basic Shielding Model</title>
+ <title>The basic shielding model</title>
  <info/>
  <para>
   Although any setup of &cpuset;s can really be described as
@@ -76,7 +76,7 @@
  </para>
 
  <sect1 xml:id="sec-shielding-model-ex">
-  <title>A Simple Shielding Example</title>
+  <title>A simple shielding example</title>
   <para> Assume that we have a 4-core machine that has uniform memory access.
    This means there are 4 CPUs at your disposal and there is only one memory node
    available. On such machines, we do not need to specify any memory node
@@ -92,7 +92,7 @@
   </para>
 
   <note>
-   <title>Definition of Task</title>
+   <title>Definition of task</title>
    <para>
     In this document <emphasis>task</emphasis> is used to represent either a
     process or a thread that is running on the system.
@@ -101,7 +101,7 @@
 </sect1>
  
  <sect1 xml:id="sec-shielding-model-ex-setup-teardown">
-   <title>Setup and Teardown of the Shield</title>
+   <title>Setup and teardown of the shield</title>
    <para>
     To set up a shield of 3 CPUs with 1 CPU left for low priority system
     processing, issue the following command.
@@ -245,7 +245,7 @@ cset: done</screen>
   </sect1>
 
   <sect1 xml:id="sec-shielding-model-ex-move">
-   <title>Moving Interesting Tasks Into and Out of the Shield</title>
+   <title>Moving interesting tasks into and out of the shield</title>
    <para>
     Now that we have a shield running, the objective is to run our
     <quote>important</quote> processes in that shield. These processes can
@@ -265,7 +265,7 @@ cset: done</screen>
     </listitem>
    </itemizedlist>
    <sect2 xml:id="sec-shielding-model-ex-move-exec">
-    <title>Execing a Process Into the Shield</title>
+    <title>Execing a process into the shield</title>
     <para>
      Running a new process in the shield can be done with the
      <option>-e/--exec</option> option to the <command>shield</command>
@@ -307,7 +307,7 @@ cset: done</screen>
      lists the PID of the new process.
     </para>
     <note>
-     <title>Separating the Tool Options From the cset Command</title>
+     <title>Separating the tool options from the <command>cset</command> command</title>
      <para>
       <command>cset</command> follows the tradition of separating the tool
       options from the command to be execed options with a double dash
@@ -328,7 +328,7 @@ cset: done</screen>
      the status command, also ran in the shield.
     </para>
     <tip>
-     <title>Execing a Shell Into the Shield Is Useful</title>
+     <title>Execing a shell into the shield is useful</title>
      <para>
       Execing a shell into the shield is a useful way to experiment with
       running tasks in the shield since all children of the shell will also
@@ -359,7 +359,7 @@ alext    14212 8583  Soth bash
 alext    14241 14212 Roth python ./cset shield -s -v</screen>
    </sect2>
    <sect2 xml:id="sec-shielding-model-ex-move-shield-unshield">
-    <title>Moving a Running Task Into and Out of the Shield</title>
+    <title>Moving a running task into and out of the shield</title>
     <para>
      While execing a process into the shield is undoubtedly useful, most of
      the time, you will want to move already running tasks into and out of
@@ -405,7 +405,7 @@ alext    14241 14212 Roth python ./cset shield -s -v</screen>
      </varlistentry>
     </variablelist>
     <note>
-     <title>Information About the Range In a PIDSPEC</title>
+     <title>Information about the range in a PIDSPEC</title>
      <para>
       A range in a PIDSPEC does not need to have tasks running for every
       number in that range. In fact, it is not even an error if there are no

--- a/xml/slert_usingshortcuts.xml
+++ b/xml/slert_usingshortcuts.xml
@@ -5,7 +5,7 @@
   %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-shortcuts">
- <title>Using Shortcuts</title>
+ <title>Using shortcuts</title>
  <para>
   The commands listed in the previous sections always used all the required
   options. However, <command>cset</command> does have a shortcut facility
@@ -79,7 +79,7 @@
   <command>set</command> need two letters to disambiguate.
  </para>
  <sect1 xml:id="sec-shielding-shortcuts-shield">
-  <title>shield Subcommand Shortcuts</title>
+  <title><command>shield</command> subcommand shortcuts</title>
 
   <para>
    The <command>shield</command> subcommand supports two areas with
@@ -172,7 +172,7 @@
   </informaltable>
  </sect1>
  <sect1 xml:id="sec-shielding-shortcuts-set">
-  <title>set Subcommand Shortcuts</title>
+  <title><command>set</command> subcommand shortcuts</title>
 
   <para>
    The <command>set</command> subcommand has a limited number of shortcuts.
@@ -259,7 +259,7 @@
 --> the -l is optional in this case since list is default</screen>
  </sect1>
  <sect1 xml:id="sec-shielding-shortcuts-proc">
-  <title><command>proc</command> Subcommand Shortcuts</title>
+  <title><command>proc</command> subcommand shortcuts</title>
 
   <para>
    For the <command>proc</command> subcommand, the <option>-s</option>, <option>-t</option> and


### PR DESCRIPTION
* The Virtualization Guide abstract still seems /rather long/, unfortunately.
* I have removed contractions and updated to sentence-style titles too
* There are quite a few terminological choices I question ("execing" ...) :/
* If anything absolutely needs to be done in addition here, feel free to edit yourself, @lproven. (I can review your changes, if you feel that's necessary.)