### PR TITLE
Reformat Virt article with `daps-xmlformat`

### DIFF
--- a/xml/article_virtualization.xml
+++ b/xml/article_virtualization.xml
@@ -7,183 +7,230 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
 ]>
-
 <article version="5.0" xml:id="article-virtualization" xml:lang="en"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Virtualization Guide</title>
-  <subtitle>&productname; &productnumber;</subtitle>
-  <info>
-   <productname>&productname;</productname>
-   <productnumber>&productnumber;</productnumber>
-   <date><?dbtimestamp?></date>
-   <abstract>
+ <title>Virtualization Guide</title>
+ <subtitle>&productname; &productnumber;</subtitle>
+ <info><productname>&productname;</productname>
+  <productnumber>&productnumber;</productnumber><date>
+<?dbtimestamp?></date>
+  <abstract>
+   <para>
+    &productname; &productnumber; supports virtualization and Docker usage as a
+    technology preview only (best-effort support).
+   </para>
+
+   <para>
+    To see the degree of interference from running within a particular &kvm;
+    configuration versus running on bare-metal configuration, Each RT
+    application has to be assessed individually. We do not give any specific
+    guarantees on performance or deadlines been missed.
+   </para>
+
+   <para>
+    Virtualization inevitably introduces overhead but there is currently no
+    rule of thumb for the performance penalty incurred. It is up to each RT
+    application developer to set performance and deadline requirements and
+    evaluate if those requirements are met.
+   </para>
+
+   <para>
+    This guide provides the following 3 examples for user reference only.
+   </para>
+  </abstract>
+ </info>
+ <sect1 xml:id="sec-virtguide-rtapp">
+  <title>Running RT applications with non-RT &kvm; guests</title>
+
+  <para>
+   It is possible to achieve isolation of real-time workloads running alongside
+   &kvm; by using standard methods. For example, cpusets and routing IRQs to
+   dedicated CPUs, all of which can be achieved by using the cset utility. Both
+   libvirtd and &kvm; work fine in such configurations. System configurations
+   that share CPUs between both RT and &kvm; workloads are not supported;
+   proper isolation of workloads is imperative for achieving RT deadline
+   constraints. None of the below observations and recommendations are specific
+   to virtualization. Nevertheless, they can be considered
+   <quote>best-effort</quote> for isolating RT and &kvm; workloads. The basic
+   steps are:
+  </para>
+
+  <procedure>
+   <step>
     <para>
-     &productname; &productnumber; supports virtualization and Docker usage
-     as a technology preview only (best-effort support).
+     <xref linkend="sec-virtguide-setup"/>
     </para>
+   </step>
+   <step>
     <para>
-     To see the degree of interference from running within a particular &kvm;
-     configuration versus running on bare-metal configuration, Each RT
-     application has to be assessed individually.
-     We do not give any specific guarantees on performance or deadlines been
-     missed.
+     <xref linkend="sec-virtguide-observations"/>
     </para>
+   </step>
+   <step>
     <para>
-     Virtualization inevitably introduces overhead but there is currently no
-     rule of thumb for the performance penalty incurred.
-     It is up to each RT application developer to set performance and
-     deadline requirements and evaluate if those requirements are met.
+     <xref linkend="sec-virtguide-rec"/>
     </para>
-    <para>
-     This guide provides the following 3 examples for user reference only.
-    </para>
-   </abstract>
-  </info>
+   </step>
+  </procedure>
 
-  <sect1 xml:id="sec-virtguide-rtapp">
-   <title>Running RT applications with non-RT &kvm; guests</title>
-   <para>It is possible to achieve isolation of real-time workloads running
-    alongside &kvm; by using standard methods. For example, cpusets and routing
-    IRQs to dedicated CPUs, all of which can be achieved by using the cset
-    utility. Both libvirtd and &kvm; work fine in such configurations. System
-    configurations that share CPUs between both RT and &kvm; workloads are not
-    supported; proper isolation of workloads is imperative for achieving RT
-    deadline constraints. None of the below observations and recommendations
-    are specific to virtualization. Nevertheless, they can be considered
-    <quote>best-effort</quote> for isolating RT and &kvm; workloads.
-    The basic steps are:</para>
-   <procedure>
-    <step>
-     <para><xref linkend="sec-virtguide-setup"/></para>
-    </step>
-    <step>
-     <para><xref linkend="sec-virtguide-observations"/></para>
-    </step>
-    <step>
-     <para><xref linkend="sec-virtguide-rec"/></para>
-    </step>
-   </procedure>
+  <sect2 xml:id="sec-virtguide-setup">
+   <title>Setup</title>
+   <para>
+    All examples were carried out on a 48-core Xeon machine with 2 NUMA nodes
+    and 64GB of RAM running &slert;. The virtual machine was installed with
+    <command>vm-install</command>, running &sls; on 4 CPUs and 2GB of memory.
+    The disk was a physical disk <filename>/dev/sdb</filename> as recommended
+    by the &sls; &virtual;.
+   </para>
+   <para>
+    The <command>cpuset</command> utility was used to shield the RT workload
+    from &kvm; as described in the <citetitle>&slea; RT Shielding
+    Guide</citetitle> (see <xref linkend="book-shielding"/>):
+   </para>
+<screen><command>cset</command> shield --kthread=on -c 8-47</screen>
+   <para>
+    Affinity for the &kvm; vCPU tasks was modified via the <command>virsh
+    vcpupin</command> command, with a 1-1 mapping. For example, vCPU&nbsp;0
+    pinned to CPU&nbsp;0, etc.
+   </para>
+   <para>
+    The CPUs were split into two groups. CPU 0-7 were allocated to the
+    <systemitem>system</systemitem> cpuset and CPU 8-47 were allocated to the
+    <systemitem>user</systemitem> group. Having CPUs on the same socket in two
+    groups was done intentionally to monitor the effects on shared CPU
+    resources, such as LLC.
+   </para>
+   <para>
+    The RT workload used throughout is cyclictest, executed like so:
+   </para>
+<screen>cset shield --exec cyclictest -- -a 8-47 -t 40 -n -m -p99 -d 0 -D 120 --quiet</screen>
+  </sect2>
 
-   <sect2 xml:id="sec-virtguide-setup">
-    <title>Setup</title>
-    <para>All examples were carried out on a 48-core Xeon machine with 2 NUMA
-    nodes and 64GB of RAM running &slert;. The virtual machine was installed
-    with <command>vm-install</command>, running &sls; on 4 CPUs and 2GB of
-    memory. The disk was a physical disk <filename>/dev/sdb</filename> as
-    recommended by the &sls; &virtual;.</para>
-    <para>The <command>cpuset</command> utility was used to shield the
-     RT workload from &kvm; as described in the
-     <citetitle>&slea; RT Shielding Guide</citetitle> (see
-     <xref linkend="book-shielding"/>):
-    </para>
-    <screen><command>cset</command> shield --kthread=on -c 8-47</screen>
-    <para>Affinity for the &kvm; vCPU tasks was modified via the <command>virsh
-     vcpupin</command> command, with a 1-1 mapping. For example, vCPU&nbsp;0
-     pinned to CPU&nbsp;0, etc.</para>
-    <para>The CPUs were split into two groups. CPU 0-7 were allocated to
-     the <systemitem>system</systemitem> cpuset and CPU 8-47 were allocated
-     to the <systemitem>user</systemitem> group. Having CPUs on the same
-     socket in two groups was done intentionally to monitor the effects on
-     shared CPU resources, such as LLC.</para>
-    <para>The RT workload used throughout is cyclictest, executed like so:</para>
-    <screen>cset shield --exec cyclictest -- -a 8-47 -t 40 -n -m -p99 -d 0 -D 120 --quiet</screen>
-   </sect2>
+  <sect2 xml:id="sec-virtguide-observations">
+   <title>Observations</title>
+   <para>
+    The following observations were made:
+   </para>
+   <orderedlist>
+    <listitem>
+<!-- xml:id="li-virtguide-observ-vmheavyio" -->
+     <para>
+      VM Heavy I/O
+     </para>
+     <para>
+      The test for this was to do the following in a VM:
+     </para>
+<screen>dd if=/dev/zero of=empty bs=4096 count=$(((80*1024*1024)/4096))</screen>
+     <para>
+      Doing large amounts of disk I/O in the VM guests has a noticeable impact
+      on the latency of RT tasks. This is because of the constant eviction of
+      LLC data, resulting in more cache misses.
+     </para>
+     <para>
+      The maximum latencies in for the real-time workload are seen on those
+      CPUs on the same socket as the CPUs available to the &kvm; workload. For
+      example, where the LLC is a shared resource between the
+      <systemitem>system</systemitem> and <systemitem>user</systemitem> cpuset.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      cpufreq drivers incur timer latency
+     </para>
+     <para>
+      Drivers like <systemitem>intel_pstate</systemitem> will set up a timer on
+      each CPU to periodically sample and adjust the CPU's current P-state. If
+      this fires at an inopportune time it can add delays to the scheduling of
+      RT tasks, particularly because lots of the IRQ/timer code paths run with
+      interrupts disabled.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Interrupt handling introduces delays
+     </para>
+     <para>
+      The handling of interrupts can result in latencies that affect RT
+      workloads. Interrupts should be routed to <quote>housekeeping</quote>
+      CPUs that are not running RT applications.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Some kernel threads cannot be controlled with cpuset
+     </para>
+     <para>
+      Performing heavy I/O in the VM may cause kthreads to be scheduled on the
+      CPUs dedicated for RT. This can occur, for example, when a kthread is
+      flushing dirty pages to disk.
+     </para>
+     <para>
+      While it is impossible to move some kworker threads into the
+      <systemitem>system</systemitem> cpuset, the above issue can be mitigated
+      by setting the CPU affinity for those threads via:
+     </para>
+<screen>/sys/devices/virtual/workqueue/writeback/cpumask</screen>
+    </listitem>
+   </orderedlist>
+  </sect2>
 
-   <sect2 xml:id="sec-virtguide-observations">
-    <title>Observations</title>
-    <para>The following observations were made:</para>
-    <orderedlist>
-     <listitem><!-- xml:id="li-virtguide-observ-vmheavyio" -->
-      <para>VM Heavy I/O</para>
-      <para>The test for this was to do the following in a VM:</para>
-      <screen>dd if=/dev/zero of=empty bs=4096 count=$(((80*1024*1024)/4096))</screen>
-      <para>Doing large amounts of disk I/O in the VM guests has a
-       noticeable impact on the latency of RT tasks. This is because of
-       the constant eviction of LLC data, resulting in more cache
-       misses.</para>
-      <para>The maximum latencies in for the real-time workload are seen on
-       those CPUs on the same socket as the CPUs available to the &kvm;
-       workload. For example, where the LLC is a shared resource between the
-       <systemitem>system</systemitem> and
-       <systemitem>user</systemitem> cpuset.</para>
-     </listitem>
-     <listitem>
-      <para>cpufreq drivers incur timer latency</para>
-      <para>Drivers like <systemitem>intel_pstate</systemitem> will set up a
-       timer on each CPU to periodically sample and adjust the CPU's
-       current P-state.
-       If this fires at an inopportune time it can add delays to the
-       scheduling of RT tasks, particularly because lots of the
-       IRQ/timer code paths run with interrupts disabled.</para>
-     </listitem>
-     <listitem>
-      <para>Interrupt handling introduces delays</para>
-      <para>The handling of interrupts can result in latencies that
-       affect RT workloads. Interrupts should be routed to
-       <quote>housekeeping</quote> CPUs that are not running RT
-       applications.</para>
-     </listitem>
-     <listitem>
-      <para>Some kernel threads cannot be controlled with cpuset</para>
-      <para>Performing heavy I/O in the VM may cause kthreads to be
-       scheduled on the CPUs dedicated for RT. This can occur, for
-       example, when a kthread is flushing dirty pages to disk.
-      </para>
-      <para>While it is impossible to move some kworker threads into
-       the <systemitem>system</systemitem> cpuset, the above issue can be
-       mitigated by setting the CPU affinity for those threads via:</para>
-      <screen>/sys/devices/virtual/workqueue/writeback/cpumask</screen>
-     </listitem>
-    </orderedlist>
-   </sect2>
+  <sect2 xml:id="sec-virtguide-rec">
+   <title>Recommendations</title>
+   <para>
+    Suggestions for tuning machines running both RT and &kvm; workloads are as
+    follows:
+   </para>
+   <orderedlist>
+    <listitem>
+     <para>
+      Affinitize RT tasks to their own CPUs, and if possible, to CPUs on their
+      own dedicated socket. Using a dedicated socket avoids the issue from
+      <xref linkend="sec-virtguide-observations"/> above where the LLC
+      occupancy is churned by VMs doing lots of I/O operations. If that is not
+      an option some customers should look at Intel's Cache Allocation
+      Technology to further enforce cache allocation policies.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Disable drivers that arm per-CPU timers such as cpufreq drivers, for
+      example, <code>intel_pstate=disable</code>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Set IRQ affinity to CPUs that are not running RT workloads and disable
+      irqbalance.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Set IRQ affinity to CPUs that are not running RT workloads. This can be
+      achieved by setting the <envar>IRQBALANCE_BANNED_CPUS</envar> environment
+      variable used by <command>irqbalance</command>(1) with a bitmask of
+      banned CPUs. For the examples used throughout this document the following
+      setting was used:
+     </para>
+<screen>IRQBALANCE_BANNED_CPUS="ffff,ffffff00"</screen>
+    </listitem>
+    <listitem>
+     <para>
+      Search for cpumask control files in <filename>/sys</filename> and set
+      them appropriately for those cases that cannot be controlled via cpuset.
+      The following command will list those files:
+     </para>
+<screen>find /sys -name cpumask</screen>
+    </listitem>
+   </orderedlist>
+  </sect2>
+ </sect1>
+ <sect1 xml:id="sec-virtguide-docker">
+  <title>Running real-time applications within Docker</title>
 
-   <sect2 xml:id="sec-virtguide-rec">
-    <title>Recommendations</title>
-    <para>Suggestions for tuning machines running both RT and &kvm;
-     workloads are as follows:</para>
-    <orderedlist>
-     <listitem>
-      <para>Affinitize RT tasks to their own CPUs, and if possible, to
-       CPUs on their own dedicated socket. Using a dedicated socket
-       avoids the issue from <xref
-        linkend="sec-virtguide-observations"/> above where the LLC
-       occupancy is churned by VMs doing lots of I/O operations. If
-       that is not an option some customers should look at
-       Intel's Cache Allocation Technology to further enforce cache
-       allocation policies.</para>
-     </listitem>
-     <listitem>
-      <para>Disable drivers that arm per-CPU timers such as cpufreq
-       drivers, for example, <code>intel_pstate=disable</code>.</para>
-     </listitem>
-     <listitem>
-      <para>Set IRQ affinity to CPUs that are not running RT workloads
-       and disable irqbalance.</para>
-     </listitem>
-     <listitem>
-      <para>Set IRQ affinity to CPUs that are not running RT workloads.
-       This can be achieved by setting the <envar>IRQBALANCE_BANNED_CPUS</envar>
-       environment variable used by <command>irqbalance</command>(1) with
-       a bitmask of banned CPUs. For the examples used throughout this
-       document the following setting was used:</para>
-      <screen>IRQBALANCE_BANNED_CPUS="ffff,ffffff00"</screen>
-     </listitem>
-     <listitem>
-      <para>Search for cpumask control files in
-       <filename>/sys</filename> and set them
-       appropriately for those cases that cannot be controlled via
-       cpuset. The following command will list those files:</para>
-      <screen>find /sys -name cpumask</screen>
-     </listitem>
-    </orderedlist>
-   </sect2>
-  </sect1>
-
-  <sect1 xml:id="sec-virtguide-docker">
-   <title>Running real-time applications within Docker</title>
-   <para> It is important to note that real-time processes will be affected by
+  <para>
+   It is important to note that real-time processes will be affected by
    container activity as there is insufficient isolation to guarantee zero
    cross-talk. There are no special settings, nor container-specific
    interactions to consider as from a RT prespective, nothing changes due to
@@ -191,73 +238,96 @@
    Interference may be considerably higher if multiple RT applications are
    executed in separate containers. Also bear in mind that while worst-case
    latency may be better than &slea;, it will not necessarily perform better
-   than NOPREEMPT due to the overhead required for RT. </para>
-   <para>
-    Some shielding is possible but there is no tool-based support for it.
-    There is a generic shield script attached that can move Docker contents
-    onto shielded cores once running. Launching of either &kvm;/Docker directly
-    into a shielded home did not appear to be possible but the Docker or
-    virtualisation team may be able to do better. The basic steps are
-   </para>
-   <procedure>
-    <step>
-     <para><xref linkend="sec-virtguide-docker-rt-env"/></para>
-    </step>
-    <step>
-     <para><xref linkend="sec-virtguide-docker-shielding"/></para>
-    </step>
-    <step>
-     <para><xref linkend="sec-virtguide-docker-scripts"/></para>
-    </step>
-   </procedure>
-   
-   <sect2 xml:id="sec-virtguide-docker-rt-env">
-    <title>Running real-time applications in a virtualized environment</title>
-    <para>
-     Standard real-time dangers apply in that if the intention is to run a
-     compute intensive application with realtime priority, then the user must
-     ensure that kernel threads cannnot starve.  A simple precaution is to
-     use <option>rtkthread=prio</option> and <option>rtworkqueues=prio</option> kernel boot
-     parameters, with priority set higher than anything that may dominate a
-     CPU. This is not strictly real-time capable, but it is safer overall.
-    </para>
-    <itemizedlist>
-     <title>Docker Prerequisites</title>
-     <listitem>
-      <para>kernel must be booted with <option>nortsched</option> command-line parameter</para>
-      <para>
-       This is to hide cgroup scheduling from Docker. If cgroup scheduling
-       is required then isolating docker is very problematic.</para>
-     </listitem>
-     <listitem>
-      <para>Docker run must be passed <option>--privileged=true</option></para>
-      <para>This is required for using the RT classes.</para>
-     </listitem>
-     <listitem>
-      <para>your container is equipped with the <command>chrt</command> system tool.</para>
-     </listitem>
-    </itemizedlist>
-    <para>
-     If no isolation is required for your use case then it's ready. Run
-     <command>docker run</command> your container, using <command>chrt</command>
-     to set RT class/priority of that which you execute upon startup of the
-     container. Example:
-    </para>
-    <screen>docker run --privileged=true ... /usr/bin/chrt -f 1 /usr/sbin/sshd -D</screen>
-    <para>
-     The above (with additional arguments of course) will start <systemitem
-      class="daemon">sshd</systemitem> within the container as a
-     <literal>SCHED_FIFO</literal> task of priority 1.  ssh into it, and
-     whatever you run therein will inherit scheduler RT class/priority.
-    </para>
-   </sect2>
+   than NOPREEMPT due to the overhead required for RT.
+  </para>
 
-   <sect2 xml:id="sec-virtguide-docker-shielding">
-    <title>Docker shielding</title>
-    <para>There is currently no facility withing Docker to launch a container directly into an isolated cpuset, this must be done manually.</para>
-    <example>
-     <title>Pseudo script</title>
-     <screen language="bash"># note cpuset mount point
+  <para>
+   Some shielding is possible but there is no tool-based support for it. There
+   is a generic shield script attached that can move Docker contents onto
+   shielded cores once running. Launching of either &kvm;/Docker directly into
+   a shielded home did not appear to be possible but the Docker or
+   virtualisation team may be able to do better. The basic steps are
+  </para>
+
+  <procedure>
+   <step>
+    <para>
+     <xref linkend="sec-virtguide-docker-rt-env"/>
+    </para>
+   </step>
+   <step>
+    <para>
+     <xref linkend="sec-virtguide-docker-shielding"/>
+    </para>
+   </step>
+   <step>
+    <para>
+     <xref linkend="sec-virtguide-docker-scripts"/>
+    </para>
+   </step>
+  </procedure>
+
+  <sect2 xml:id="sec-virtguide-docker-rt-env">
+   <title>Running real-time applications in a virtualized environment</title>
+   <para>
+    Standard real-time dangers apply in that if the intention is to run a
+    compute intensive application with realtime priority, then the user must
+    ensure that kernel threads cannnot starve. A simple precaution is to use
+    <option>rtkthread=prio</option> and <option>rtworkqueues=prio</option>
+    kernel boot parameters, with priority set higher than anything that may
+    dominate a CPU. This is not strictly real-time capable, but it is safer
+    overall.
+   </para>
+   <itemizedlist>
+    <title>Docker Prerequisites</title>
+    <listitem>
+     <para>
+      kernel must be booted with <option>nortsched</option> command-line
+      parameter
+     </para>
+     <para>
+      This is to hide cgroup scheduling from Docker. If cgroup scheduling is
+      required then isolating docker is very problematic.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Docker run must be passed <option>--privileged=true</option>
+     </para>
+     <para>
+      This is required for using the RT classes.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      your container is equipped with the <command>chrt</command> system tool.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    If no isolation is required for your use case then it's ready. Run
+    <command>docker run</command> your container, using <command>chrt</command>
+    to set RT class/priority of that which you execute upon startup of the
+    container. Example:
+   </para>
+<screen>docker run --privileged=true ... /usr/bin/chrt -f 1 /usr/sbin/sshd -D</screen>
+   <para>
+    The above (with additional arguments of course) will start
+    <systemitem class="daemon">sshd</systemitem> within the container as
+    a <literal>SCHED_FIFO</literal> task of priority 1. ssh into it, and
+    whatever you run therein will inherit scheduler RT class/priority.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-virtguide-docker-shielding">
+   <title>Docker shielding</title>
+   <para>
+    There is currently no facility withing Docker to launch a container
+    directly into an isolated cpuset, this must be done manually.
+   </para>
+   <example>
+    <title>Pseudo script</title>
+<screen language="bash"># note cpuset mount point
 cpuset_mnt=$(mount|grep cpuset|cut -d' ' -f3)
 
 # create an isolated cpuset for your container
@@ -282,14 +352,14 @@ rmdir ${cpuset_mnt}/system/docker
 
 # tear down the shield, and you're done
 cset shield --userset=rtcpus --cpu=4-7 --reset</screen>
-    </example>
-   </sect2>
+   </example>
+  </sect2>
 
-   <sect2 xml:id="sec-virtguide-docker-scripts">
-    <title>Scripts</title>
-    <example>
-     <title>Sample shield script</title>
-     <screen language="bash">#!/bin/sh
+  <sect2 xml:id="sec-virtguide-docker-scripts">
+   <title>Scripts</title>
+   <example>
+    <title>Sample shield script</title>
+<screen language="bash">#!/bin/sh
 
 let START_CPU=4
 let END_CPU=63
@@ -478,11 +548,10 @@ if [ -f /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor ]; then
     done
   fi
 fi</screen>
-    </example>
-
-    <example>
-     <title>Patch to <literal>sysjitter</literal> to use the user affinity instead of whole box</title>
-     <screen language="diff">sysjitter.c |   10 +++++++---
+   </example>
+   <example>
+    <title>Patch to <literal>sysjitter</literal> to use the user affinity instead of whole box</title>
+<screen language="diff">sysjitter.c |   10 +++++++---
  1 file changed, 7 insertions(+), 3 deletions(-)
 
 --- a/sysjitter.c
@@ -520,51 +589,61 @@ fi</screen>
  			threads[g.n_threads++].core_i = i;
  
  	signal(SIGALRM, handle_alarm);</screen>
-    </example>
-   </sect2>
-  </sect1>
-
+   </example>
+  </sect2>
+ </sect1>
  <sect1 xml:id="sec-virtguide-rtkvmguests">
   <title>Running RT applications with RT &kvm; guests</title>
+
   <para>
-   In <xref linkend="sec-virtguide-rtapp"/>, we see that it is possible
-   to isolate real-time workloads running alongside &kvm;
-   by using standard methods. In &slea; RT 15 SP2 this can be done in user space 
-   using libvirt/qemu.
+   In <xref linkend="sec-virtguide-rtapp"/>, we see that it is possible to
+   isolate real-time workloads running alongside &kvm; by using standard
+   methods. In &slea; RT 15 SP2 this can be done in user space using
+   libvirt/qemu.
   </para>
+
   <para>
-   Applications and guest operating systems run inside &kvm; guests similarly to 
-   how they run on bare metal. The guest interfaces with emulated hardware presented 
-   by &qemu;, which submits I/O requests to the host on behalf of the guest. 
-   Then the host kernel treats the guest I/Os like any user-space application.
+   Applications and guest operating systems run inside &kvm; guests similarly
+   to how they run on bare metal. The guest interfaces with emulated hardware
+   presented by &qemu;, which submits I/O requests to the host on behalf of the
+   guest. Then the host kernel treats the guest I/Os like any user-space
+   application.
   </para>
+
   <para>
-   In &slea; RT 15 SP3, both &qemu; and libvirt support isolating the CPUs, 
-   partitioning the memory for guests, and setting the vCPU/iothread scheduler 
+   In &slea; RT 15 SP3, both &qemu; and libvirt support isolating the CPUs,
+   partitioning the memory for guests, and setting the vCPU/iothread scheduler
    policy and priority for running both non-RT &kvm; and RT &kvm;.
   </para>
+
   <sect2 xml:id="sec-virtguide-rtkvmguests-suport">
    <title>Support of &qemu;/libvirt</title>
    <orderedlist>
     <listitem>
-     <para>&qemu; includes the <option>-realtime mlock=on|off</option> option. 
-      Mlocking &qemu; and guest memory is enabled with 
-      <option>mlock=on</option> (which is enabled by default) <!--where is it
-         enabled?-->.
+     <para>
+      &qemu; includes the <option>-realtime mlock=on|off</option> option.
+      Mlocking &qemu; and guest memory is enabled with
+      <option>mlock=on</option> (which is enabled by default)
+<!--where is it
+         enabled?-->
+      .
      </para>
     </listitem>
     <listitem>
      <para>
       libvirt supports CPU Allocation, CPU Tuning, and Memory Backing, which
-      allows you to control RT parameters, see <xref
+      allows you to control RT parameters, see
+      <xref
        linkend="sec-virtguide-rtkvmguests-sample"/>.
      </para>
      <variablelist>
       <varlistentry>
        <term>CPU allocation</term>
        <listitem>
-        <para>We can define the maximum number of virtual CPUs allocated for
-         the guest OS.</para>
+        <para>
+         We can define the maximum number of virtual CPUs allocated for the
+         guest OS.
+        </para>
        </listitem>
       </varlistentry>
       <varlistentry>
@@ -572,20 +651,25 @@ fi</screen>
        <listitem>
         <itemizedlist>
          <listitem>
-          <para>Pinning is a tuning option for the virtual CPUs in &kvm; guests.
-           With pinning we can control where the guest runs in order to reduce 
-           the overhead of scheduler switches, pin vCPUs to physical CPUs 
-           that have low utilization, and improve the data cache performance. 
-           Overall performance is improved when the memory that an
-           application uses is local to the physical CPU, and the guest vCPU
-           is pinned to this physical CPU.</para>
+          <para>
+           Pinning is a tuning option for the virtual CPUs in &kvm; guests.
+           With pinning we can control where the guest runs in order to reduce
+           the overhead of scheduler switches, pin vCPUs to physical CPUs that
+           have low utilization, and improve the data cache performance.
+           Overall performance is improved when the memory that an application
+           uses is local to the physical CPU, and the guest vCPU is pinned to
+           this physical CPU.
+          </para>
          </listitem>
          <listitem>
-          <para>We can specify the vCPU scheduler type (values batch, idle, 
-           fifo, rr), and priority for particular vCPU threads. Priority <literal>99</literal>
-           is too high, and it will massively interfere with the host's 
-           ability to function properly. There are host-side per-CPU threads 
-           that must be always be able to preempt, for example, timer sirq threads.</para>
+          <para>
+           We can specify the vCPU scheduler type (values batch, idle, fifo,
+           rr), and priority for particular vCPU threads. Priority
+           <literal>99</literal> is too high, and it will massively interfere
+           with the host's ability to function properly. There are host-side
+           per-CPU threads that must be always be able to preempt, for example,
+           timer sirq threads.
+          </para>
          </listitem>
         </itemizedlist>
        </listitem>
@@ -594,9 +678,9 @@ fi</screen>
        <term>Memory backing</term>
        <listitem>
         <para>
-         Use memory backing to allocate enough memory in the guest to avoid 
-         memory overcommit, and to lock the guest page memory in host memory 
-         to prevent it from being swapped out. This will show a performance 
+         Use memory backing to allocate enough memory in the guest to avoid
+         memory overcommit, and to lock the guest page memory in host memory to
+         prevent it from being swapped out. This will show a performance
          improvement in some workloads.
         </para>
        </listitem>
@@ -605,9 +689,10 @@ fi</screen>
     </listitem>
    </orderedlist>
   </sect2>
+
   <sect2 xml:id="sec-virtguide-rtkvmguests-sample">
    <title>Sample of <filename>libvirt.xml</filename></title>
-   <screen language="xml"><![CDATA[<domain>
+<screen language="xml"><![CDATA[<domain>
    …
    <vcpu placement='static' cpuset="1-4,^3,6" current="1">4</vcpu>
    …
@@ -625,60 +710,68 @@ fi</screen>
    …
 </domain>]]></screen>
   </sect2>
+
   <sect2 xml:id="sec-virtguide-rtkvmguests-othersettings">
    <title>Other host settings</title>
    <orderedlist>
     <listitem>
      <formalpara>
       <title>Power management</title>
-      <para>Intel processors have a power management feature that puts the system
-       into power-saving mode when the system is under-utilized. The system 
-       should be configured for maximum performance, rather than allowing 
-       power-saving mode.</para>
+      <para>
+       Intel processors have a power management feature that puts the system
+       into power-saving mode when the system is under-utilized. The system
+       should be configured for maximum performance, rather than allowing
+       power-saving mode.
+      </para>
      </formalpara>
     </listitem>
     <listitem>
      <formalpara>
       <title>Turboboost and Speedstep</title>
-      <para>Turboboost overclocks a core when CPU demand is high,
-       whereas Speedstep dynamically adjusts the frequency of processor to meet 
-       processing needs. Turboboost requires Speedstep to be enabled, as it is 
-       an extension of Speedstep. For maximum performance, enable both Turboboost 
-       and Speedstep in BIOS. The host OS may also need configuration
-       to support running at higher clock speeds. For example:</para>
+      <para>
+       Turboboost overclocks a core when CPU demand is high, whereas Speedstep
+       dynamically adjusts the frequency of processor to meet processing needs.
+       Turboboost requires Speedstep to be enabled, as it is an extension of
+       Speedstep. For maximum performance, enable both Turboboost and Speedstep
+       in BIOS. The host OS may also need configuration to support running at
+       higher clock speeds. For example:
+      </para>
      </formalpara>
-     <screen><command>cpupower</command> -c all frequency-set -g performance</screen>
+<screen><command>cpupower</command> -c all frequency-set -g performance</screen>
     </listitem>
     <listitem>
      <formalpara>
       <title>Disable interrupt balancing (irqbalance)</title>
-      <para>The irqbalance daemon is enabled by default. It distributes hardware 
-       interrupts across CPUs in a multi-core system to increase performance. 
-       When irqbalance is disabled, all interrupts will be handled by cpu0, 
-       and therefore the guest should NOT run on cpu0.
+      <para>
+       The irqbalance daemon is enabled by default. It distributes hardware
+       interrupts across CPUs in a multi-core system to increase performance.
+       When irqbalance is disabled, all interrupts will be handled by cpu0, and
+       therefore the guest should NOT run on cpu0.
       </para>
      </formalpara>
     </listitem>
     <listitem>
      <formalpara>
       <title>RT throttling</title>
-      <para>The default values for the realtime throttling mechanism allocate
-       95% of the CPU time to realtime tasks, and the remaining 5% to 
-       non-realtime tasks. If RT throttling is disabled, realtime tasks may use 
-       up to 100% of CPU time. Hence, programming failures in real-time 
-       applications can cause the entire system to hang because no other task 
-       can preempt the realtime tasks.</para>
+      <para>
+       The default values for the realtime throttling mechanism allocate 95% of
+       the CPU time to realtime tasks, and the remaining 5% to non-realtime
+       tasks. If RT throttling is disabled, realtime tasks may use up to 100%
+       of CPU time. Hence, programming failures in real-time applications can
+       cause the entire system to hang because no other task can preempt the
+       realtime tasks.
+      </para>
      </formalpara>
     </listitem>
    </orderedlist>
    <para>
-    The above settings are just part of the configurations for the RT
-    &kvm; to run at the <quote>best-effort</quote> performance. Other factors must be
-    considered, such as storage and network. The overall &kvm;
-    performance is dependent on the host hardware, firmware, BIOS settings, and
-    the guest OS and application charactistics. </para>
+    The above settings are just part of the configurations for the RT &kvm; to
+    run at the <quote>best-effort</quote> performance. Other factors must be
+    considered, such as storage and network. The overall &kvm; performance is
+    dependent on the host hardware, firmware, BIOS settings, and the guest OS
+    and application charactistics.
+   </para>
   </sect2>
  </sect1>
-
  <xi:include href="common_legal.xml"/>
 </article>


### PR DESCRIPTION
Again, I plan a copy-edit of the SLERT virtualization guide. As step 1 I reformatted with DAPS  (and manually tightened up some resulting gaps in links). The result is a much bigger diff than I expected.

Does this look OK?