### PR TITLE
Use suse2022-ns stylesheets for SLE-RT en-us

### DIFF
--- a/DC-SLE-RT-all
+++ b/DC-SLE-RT-all
@@ -8,4 +8,4 @@ MAIN=MAIN.SLERT.xml
 PROFOS="slert"
 
 # Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLE-RT-hardware-testing
+++ b/DC-SLE-RT-hardware-testing
@@ -8,4 +8,4 @@ ROOTID=article-hardware-testing
 PROFOS="slert"
 
 # Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLE-RT-kernel-tasks
+++ b/DC-SLE-RT-kernel-tasks
@@ -8,4 +8,4 @@ PROFOS="sles"
 ## PROFCONDITION="noquick;suse-product"
 
 # Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLE-RT-setup
+++ b/DC-SLE-RT-setup
@@ -8,4 +8,4 @@ ROOTID=article-setup
 PROFOS="slert"
 
 # Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLE-RT-shielding
+++ b/DC-SLE-RT-shielding
@@ -8,4 +8,4 @@ ROOTID=book-shielding
 PROFOS="slert"
 
 # Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLE-RT-virtualization
+++ b/DC-SLE-RT-virtualization
@@ -8,4 +8,4 @@ ROOTID=article-virtualization
 PROFOS="slert"
 
 # Stylesheets
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"


### PR DESCRIPTION
### Description

We want to switch to the new 3-column layout. This PR uses the new stylesheets.


### Which product versions do the changes apply to?

* [x] `maintenance/SLERT15SP3`: 
* [x] `maintenance/SLERT15SP2`: 
* [x] `maintenance/SLERT15SP1`: 
* [x] `maintenance/SLERT15`: 
* [x] `maintenance/SLERT12SP5`: 
