### PR TITLE
Use consistent PR templates across all SLE repos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+### Description
+
+Describe this pull request.
+
+### Are there any relevant issues/feature requests?
+
+* bsc#...
+* jsc#...
+
+### Which product versions do the changes apply to?
+
+SLE-RT 15
+- [ ] 15 next *(current `main`, no backport necessary)*
+- [ ] 15 SP4
+- [ ] 15 SP3
+
+SLE-RT 12
+- [ ] 12 SP5
+
+### PR reviewer only: Have all backports been applied?
+
+The doc team member merging your PR will take care of backporting to older documents.
+When opening a PR, do *not* set the following check box.
+
+- [ ] all necessary backports are done


### PR DESCRIPTION
Added PR template based on what we have in doc-sle. Listed only the SLE-RT versions that are still supported.