### PR TITLE
Review cpuset shielding

### DIFF
--- a/xml/book_slert_shielding.xml
+++ b/xml/book_slert_shielding.xml
@@ -26,6 +26,7 @@
   </info>
  <xi:include href="slert_intro.xml" parse="xml"/>
  <xi:include href="slert_shielding_model.xml" parse="xml"/>
+ <xi:include href="slert_systemd_shielding.xml" parse="xml"/>
  <xi:include href="slert_cpuset_manipulation.xml" parse="xml"/>
  <xi:include href="slert_usingshortcuts.xml" parse="xml"/>
  <xi:include href="slert_gettinghelp.xml" parse="xml"/>

--- a/xml/slert_cpuset_manipulation.xml
+++ b/xml/slert_cpuset_manipulation.xml
@@ -574,104 +574,20 @@ two          2 n          0 n       0     0    /two
 three        3 n          0 n       10    0    /three</screen>
    </sect3>
    <sect3 xml:id="sec-shielding-cpuset-proc-move-threads">
-    <title>Moving kernel threads with <command>proc</command></title>
+    <title>Kernel threads and <command>proc</command></title>
     <para>
      Kernel threads are special and <command>cset</command> detects tasks
-     that are kernel threads and will refuse to move them unless you also
-     add a <option>-k/--kthread</option> option to your
-     <command>proc</command> move command. Even if you include
-     <option>-k</option>, <command>cset</command> will still refuse to move
-     the kernel thread if they are bound to specific CPUs. The reason for
-     this is system protection.
-    </para>
-    <para>
-     Several kernel threads, especially on the real-time Linux kernel,
-     are bound to specific CPUs and depend on per-CPU kernel variables. If
-     you move these threads to a different CPU than what they are bound to,
-     you risk at best that the system will become horribly slow, and at
-     worst a system hang. If you must move those threads (after all,
-     <command>cset</command> needs to give the knowledgeable user access to
-     the keys), then you also need to use the <option>--force</option>
-     option.
+     that are kernel threads and will refuse to move them (since they typically
+     play a vital role on particular CPU).
     </para>
     <warning>
-     <title>Use <option>--force</option> with care</title>
+     <title>Use <option>-k</option> or <option>--force</option> with care</title>
      <para>
-      Overriding a task move command with <option>--force</option> can have
-      dire consequences for the system. Be sure of the command before you
-      force it.
+       Overriding a task move command with <option>-k</option> or <option>--force</option>
+       can have dire consequences for the system. Be sure of the command before
+       you force it.
      </para>
     </warning>
-    <para>
-     The following example moves all unbound kernel threads running in
-     the root cpuset to the cpuset named two by using the
-     <option>-k</option> option.
-    </para>
-<screen>&prompt.user;<command>cset</command> proc -k -f root -t two
-cset: moving all kernel threads from / to /two
-cset: moving 70 kernel threads to: /two
-cset: --> not moving 76 threads (not unbound, use --force)
-[==================================================]%
-cset: done</screen>
-    <para>
-     This example uses the fromset→toset facility of the
-     <command>proc</command> subcommand. However, it only specifies the
-     <option>-k</option> option (not the <option>-m</option> option). This
-     has the effect of moving all kernel threads only.
-    </para>
-    <para>
-     Note that only 70 actual kernel threads were moved and 76 were not. The
-     reason that 76 kernel threads were not moved was because they are bound
-     to specific CPUs. Now, let us move those kernel threads back to
-     <literal>root</literal>.
-    </para>
-<screen>&prompt.user;<command>cset</command> proc -k -f two -t root
-cset: moving all kernel threads from /two to /
-cset: ** no task matched move criteria
-cset: **> kernel tasks are bound, use --force if ok
-
-
-&prompt.user;<command>cset</command> set -l -s two
-cset:
-Name         CPUs-X       MEMs-X    Tasks Subs Path
------------- ---------- - ------- - ----- ---- ----------
-two          2 n          0 n       70    0    /two</screen>
-    <para>
-     <command>cset</command> refused to move the kernel threads back to
-     <literal>root</literal> because it says that they are
-     <quote>bound</quote>. Let us check this with the
-     <command>taskset</command> command.
-    </para>
-<screen>&prompt.user;<command>cset</command> proc -l -s two | head -5
-cset: "two" cpuset of CPUSPEC(2) with 70 tasks running
-USER     PID   PPID  SPPr TASK NAME
--------- ----- ----- ---- ---------
-root         2     0 Soth [kthreadd]
-root        55     2 Soth [khelper]
-
-
-&prompt.user;<command>taskset</command> -p 2
-pid 2's current affinity mask: 4
-
-
-&prompt.user;<command>cset</command> set -l -s two
-cset:
-Name         CPUs-X       MEMs-X    Tasks Subs Path
------------- ---------- - ------- - ----- ---- ----------
-two          2 n          0 n       70    0    /two</screen>
-    <para>
-     Of course, since the cpuset named <literal>two</literal> only has CPU2
-     assigned to it, after it was moved the unbound kernel threads from
-     <literal>root</literal> to <literal>two</literal>, their affinity masks
-     got automatically changed to only use CPU2. This is evident from the
-     <command>taskset</command> output which is a hex value. To really move
-     these threads back to root, force the move as follows:
-    </para>
-<screen>&prompt.user;<command>cset</command> proc -k -f two -t root --force
-cset: moving all kernel threads from /two to /
-cset: moving 70 kernel threads to: /
-[==================================================]%
-cset: done</screen>
    </sect3>
   </sect2>
 
@@ -717,8 +633,7 @@ cset: done</screen>
    unimportant system tasks; and <literal>user</literal>, which is the
    <emphasis>shielded</emphasis> set of CPUs and runs your important tasks.
    Remember also that <command>shield</command> moves all movable tasks into
-   <literal>system</literal> and, optionally, moves unbound kernel threads
-   into <literal>system</literal> as well.
+   <literal>system</literal> (except for kernel threads).
   </para>
 
   <para>
@@ -771,27 +686,11 @@ system       0 n          0 n       187    0   /system</screen>
    will also run in <literal>system</literal>. The <literal>user</literal>
    cpuset has nothing running in it unless you put tasks there with the
    <command>proc</command> subcommand as described above. If you also want
-   to move movable kernel threads from <literal>root</literal> to
-   <literal>system</literal> (to achieve a form of <quote>interrupt
-   shielding</quote> on a real time Linux kernel, for example), you would
-   execute the following command as well:
+   to eliminate kernel threads from <literal>root</literal> that could interfere
+   with <literal>user</literal> workload (to achieve a form of <quote>interrupt
+   shielding</quote> on a real time Linux kernel, for example), you should look 
+   at <literal>isolcpus=</literal> kernel command line argument.
   </para>
-
-<screen>&prompt.user;<command>cset</command> proc -k -f root -t system
-cset: moving all kernel threads from / to /system
-cset: moving 70 kernel threads to: /system
-cset: --> not moving 76 threads (not unbound, use --force)
-[==================================================]%
-cset: done
-
-
-&prompt.user;<command>cset</command> set -l
-cset:
-Name         CPUs-X       MEMs-X    Tasks Subs Path
------------- ---------- - ------- - ----- ---- ----------
-root         0-3 y        0 y       76    2    /
-user         1-3 n        0 n       0     0    /user
-system       0 n          0 n       257   0    /system</screen>
 
   <para>
    At this point, you have achieved the simple shielding model that the
@@ -924,15 +823,13 @@ prio_low     3 n          0 n       0     0    /prio_all/pr...rio_med/prio_low</
 
   <para>
    The strategy is now implemented. This means that you can move all user space
-   tasks and all movable kernel threads into the <literal>system</literal>
-   cpuset to activate the shield.
+   tasks into the <literal>system</literal> cpuset to activate the shield.
   </para>
 
-<screen>&prompt.user;<command>cset</command> proc -m -k -f root -t system
+<screen>&prompt.user;<command>cset</command> proc -m -f root -t system
 cset: moving all tasks from root to /system
 cset: moving 198 userspace tasks to /system
-cset: moving 70 kernel threads to: /system
-cset: --> not moving 76 threads (not unbound, use --force)
+cset: *** not moving kernel threads, need both --force and --kthread
 [==================================================]%
 cset: done
 
@@ -941,8 +838,8 @@ cset: done
 cset:
 Name         CPUs-X       MEMs-X    Tasks Subs Path
 ------------ ---------- - ------- - ----- ---- ----------
-root         0-3 y        0 y       76    2    /
-system       0 n          0 n       268   0    /system
+root         0-3 y        0 y       146    2    /
+system       0 n          0 n       198   0    /system
 prio_all     0-3 n        0 n       0     1    /prio_all
 prio_high    1-3 n        0 n       0     1    /prio_all/prio_high
 prio_med     2-3 n        0 n       0     1    /prio_all/prio_high/prio_med
@@ -967,8 +864,8 @@ prio_low     3 n          0 n       0     0    /prio_all/pr...rio_med/prio_low</
 cset:
 Name         CPUs-X       MEMs-X    Tasks Subs Path
 ------------ ---------- - ------- - ----- ---- ----------
-root         0-3 y        0 y       76    2    /
-system       0 n          0 n       268   0    /system
+root         0-3 y        0 y       146    2    /
+system       0 n          0 n       198   0    /system
 prio_all     0-3 n        0 n       0     1    /prio_all
 prio_high    1-3 n        0 n       0     1    /prio_all/prio_high
 prio_med     2-3 n        0 n       0     1    /prio_all/prio_high/prio_med

--- a/xml/slert_gettinghelp.xml
+++ b/xml/slert_gettinghelp.xml
@@ -8,11 +8,6 @@
  <title>What to do if there are problems</title>
  <info/>
  <para>
-  If you encounter any issues with the <command>cset</command> application,
-  you can file a bug report here:
-  <link xlink:href="https://github.com/lpechacek/cpuset/issues"/>
- </para>
- <para>
   If you are using <command>cset</command> on a supported operating system
   such as &sls; &productnumber; or &slerte; &productnumber;,
   then should use the following Bugzilla product listing here:

--- a/xml/slert_intro.xml
+++ b/xml/slert_intro.xml
@@ -6,6 +6,14 @@
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-intro">
  <title>Introduction</title>
+  <note>
+   <title>cset and cgroup version</title>
+   <para>The <command>cset</command> utility supports cpuset controller only
+   on v1 hierarchy (legacy or hybrid in systemd lingo). On a system with the
+   unified (v2) hierarchy, <command>cset</command> is not supported and
+   cpuset controller can be used via systemd.
+   </para>
+  </note>
  <para>
   In the Linux kernel, the cpuset facility provides a mechanism for creating
   logical entities called <quote>cpusets</quote> that encompass definitions

--- a/xml/slert_shielding_model.xml
+++ b/xml/slert_shielding_model.xml
@@ -54,10 +54,8 @@
   The subcommand automatically moves all movable tasks on the system into the
   <literal>unshielded</literal> &cpuset; on shield activation, and back into
   the <systemitem>root</systemitem> &cpuset; on shield tear down. The subcommand
-  lets you move tasks into and out of the shield. Additionally, you can move
-  special tasks (kernel threads) which normally run in the
-  <systemitem>root</systemitem> &cpuset; into the <literal>unshielded</literal>
-  set. This makes your shield have even less disturbance.
+  lets you move tasks into and out of the shield. Kernel threads are excluded
+  from these migrations.
  </para>
  <para>
   The <command>shield</command> subcommand abstracts the management of these &cpuset;s away from
@@ -131,8 +129,7 @@ cset: "user" cpuset of CPUSPEC(1-3) with 0 tasks running</screen>
     Note that the command did not move the kernel threads that are running
     in the <literal>root</literal> &cpuset; to the <literal>system</literal>
     &cpuset;. This is because you may want these kernel threads to use all
-    available CPUs. If you do not, then you can use the
-    <option>-k</option>/<option>--kthread</option> option as described below.
+    available CPUs.
    </para>
    <para>
     The shield setup command above outputs the information of which &cpuset;s
@@ -164,9 +161,8 @@ cset: "user" cpuset of CPUSPEC(1-3) with 0 tasks running</screen>
    </para>
   </formalpara>
    <para>
-    Some kernel threads can be moved into the unshielded
-    <literal>system</literal> &cpuset; as well. These are the threads that are
-    not bound to specific CPUs. If a kernel thread is bound to a specific
+    Kernel threads can be both unbound or bound to specific CPUs.
+    If a kernel thread is bound to a specific
     CPU, then it is generally not a good idea to move that thread to the
     <literal>system</literal> set because at worst it may hang the system
     and at best it will slow the system down significantly. These threads
@@ -177,27 +173,9 @@ cset: "user" cpuset of CPUSPEC(1-3) with 0 tasks running</screen>
    </para>
    <para>
     However, if your application demands an even <quote>quieter</quote>
-    shield, then you can move all movable kernel threads into the unshielded
-    <literal>system</literal> set with the following command.
+    shield, you should look at <literal>isolcpus=</literal> kernel command line
+    argument.
    </para>
-<screen>&prompt.user;<command>cset</command> shield -k on
-cset: --> activating kthread shielding
-cset: kthread shield activated, moving 70 tasks into system cpuset...
-[==================================================]%
-cset: done</screen>
-   <para>
-    You can see that this moved an additional 70 tasks to the unshielded
-    <literal>system</literal> &cpuset;. Note that the <option>-k</option
-    >/<option>--kthread on</option> parameter can be given at the shield's
-    creation time. You do not need to perform these two steps separately if you know
-    you will want kernel thread shielding as well. Executing
-    <command>cset shield</command> again shows us the current state of the
-    shield.
-   </para>
-<screen>&prompt.user;<command>cset</command> shield
-cset: --> shielding system active with
-cset: "system" cpuset of CPUSPEC(0) with 246 tasks running
-cset: "user" cpuset of CPUSPEC(1-3) with 0 tasks running</screen>
    <para>
     You can get a detailed listing of what is running in the shield by
     adding either <option>-s/--shield</option> or

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -33,7 +33,10 @@
    </para>
    <para>
            We must configure <emphasis>all</emphasis> of these units not to stand in the way of our main workload.
-           For instance with following drop-in file(s): (TODO link to https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-systemd.html#sec-boot-systemd-custom-drop-in)
+           For instance with following
+	   <link
+	   xlink:href="https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-systemd.html#sec-boot-systemd-custom-drop-in">
+	   drop-in file(s)</link>:
    </para>
    <screen>&prompt.root; cat /etc/systemd/system/init.scope.d/40-shielding.conf
 [Scope]

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -12,9 +12,9 @@
  <info/>
  <para>
   systemd has native support for the cpuset controller since version 244.
-  Shielding the sensitive workload can be achieved by proper configuration of respective units.
+  Shielding the sensitive workload can be achieved with the proper configuration of respective units.
   This is only supported with cgroup unified hierarchy (v2) and hence the shielded
-  vs unshielded division copies the structure of typical systemd cgroup tree.
+  vs. unshielded division copies the structure of typical systemd cgroup tree.
  </para>
 
  <sect1 xml:id="sec-systemd-shielding-teardown">
@@ -55,7 +55,7 @@ AllowedCPUs=0-1
 AllowedCPUs=2-15
 </screen>
 <para>
-        The setup can also be changed at runtime (for debugging reasons)
+        The setup can also be changed at runtime (for debugging reasons):
 </para>
 <screen>&prompt.root; systemctl set-property --runtime init.scope AllowedCPUs=0-1
 &prompt.root; systemctl set-property --runtime system.slice AllowedCPUs=0-1
@@ -80,7 +80,7 @@ Slice=workload.slice
 <screen>&prompt.root; systemd-run --scope -p Slice=workload.slice command arg1 ...</screen>
 <note>
         <para>Existing processes cannot be moved under the shield since that would involve process migration between cgroups which would cause distortion of the accounting state.
-        But sensitive workload should start with their resources ensured in advance anyway.</para>
+        But sensitive workload should start with their resources secured in advance anyway.</para>
 </note>
  </sect1>
 </chapter>

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -23,7 +23,7 @@
         The general idea is to have one cpuset for the main sensitive workload
         and a complementary cpuset for the supporting tasks.
         Resources are distributed in the top-down fashion, so to ensure proper
-        allocation for the main workload we must take into consideration the
+        allocation for the main workload we must take into consideration all the
         top-level cgroups on the system.
         systemd by default creates the following units:
            <literal>init.scope</literal>,
@@ -45,10 +45,10 @@ AllowedCPUs=0-1
 </screen>
 
 <para>
-        This way we constrain the system workload just to the first two CPUs.
+        This way we constrain the supporting system workload just to the first two CPUs.
 </para>
 <para>
-        Finally, we create a dedicated slice for our workload with all the remaining systemd CPUs:
+        Finally, we create a dedicated slice for our sensitive workload with all the remaining system CPUs:
 </para>
 <screen>&prompt.root; cat /etc/systemd/system/workload.slice
 [Slice]
@@ -57,9 +57,9 @@ AllowedCPUs=2-15
 <para>
         The setup can also be changed at runtime (for debugging reasons):
 </para>
-<screen>&prompt.root; systemctl set-property --runtime init.scope AllowedCPUs=0-1
-&prompt.root; systemctl set-property --runtime system.slice AllowedCPUs=0-1
-...
+<screen>&prompt.root; systemctl set-property --runtime workload.slice AllowedCPUs=4-15
+&prompt.root; systemctl set-property --runtime init.scope AllowedCPUs=0-3
+&prompt.root; systemctl set-property --runtime system.slice AllowedCPUs=0-3
 </screen>
  </sect1>
  <sect1 xml:id="sec-shielding-systemd-ex-move">

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -5,7 +5,7 @@
   %entities;
 ]>
 
-<chapter version="5.0" xml:id="cha-shielding-model"
+<chapter version="5.0" xml:id="cha-shielding-with-systemd"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xlink="http://www.w3.org/1999/xlink">
 <title>Shielding with systemd</title>
@@ -43,7 +43,7 @@ AllowedCPUs=0-1
 [Slice]
 AllowedCPUs=0-1
 </screen>
-...
+
 <para>
         This way we constrain the system workload just to the first two CPUs.
 </para>
@@ -66,21 +66,21 @@ AllowedCPUs=2-15
     <title>Running jobs in the shield</title>
     <para>
     When the <literal>workload.slice</literal> is prepared according to the previous section, running the sensitive jobs is as simple as configuring their service into that slice.
-    <para>
+    </para>
    <screen>&prompt.root; cat /etc/systemd/system/sensitive.service.d/40-shielding.conf
 [Service]
 Slice=workload.slice
 </screen>
 <note>
-        Beware that the <literal>Slice=</literal> directive only takes effect upon service (re)start.
+    <para>Beware that the <literal>Slice=</literal> directive only takes effect upon service (re)start.</para>
 </note>
 <para>
         Should not the sensitive job have a form of a service but an ad-hoc command, you may start it in a systemd scope:
 </para>
 <screen>&prompt.root; systemd-run --scope -p Slice=workload.slice command arg1 ...</screen>
 <note>
-        Existing processes cannot be moved under the shield since that would involve process migration between cgroups which would cause distortion of the accounting state.
-        But sensitive workload should start with their resources ensured in advance anyway.
+        <para>Existing processes cannot be moved under the shield since that would involve process migration between cgroups which would cause distortion of the accounting state.
+        But sensitive workload should start with their resources ensured in advance anyway.</para>
 </note>
  </sect1>
 </chapter>

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -11,7 +11,7 @@
 <title>Shielding with systemd</title>
  <info/>
  <para>
-  systemd has native support for the cpuset controller since version 244.
+  systemd has native support for the cpuset controller since &productname; 15 SP4.
   Shielding the sensitive workload can be achieved with the proper configuration of respective units.
   This is only supported with cgroup unified hierarchy (v2) and hence the shielded
   vs. unshielded division copies the structure of typical systemd cgroup tree.
@@ -28,21 +28,21 @@
         systemd by default creates the following units:
            <literal>init.scope</literal>,
            <literal>system.slice</literal>,
-           <literal>user.slice</literal> and
+           <literal>user.slice</literal>, and
            <literal>machine.slice</literal>.
    </para>
    <para>
            We must configure <emphasis>all</emphasis> of these units not to stand in the way of our main workload.
            For instance with following
-	   <link
-	   xlink:href="https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-systemd.html#sec-boot-systemd-custom-drop-in">
-	   drop-in file(s)</link>:
+           <link
+           xlink:href="https://documentation.suse.com/sles/15/html/SLES-all/cha-systemd.html#sec-boot-systemd-custom-drop-in">
+           drop-in file(s)</link>:
    </para>
-   <screen>&prompt.root; cat /etc/systemd/system/init.scope.d/40-shielding.conf
+   <screen>&prompt.root;cat /etc/systemd/system/init.scope.d/40-shielding.conf
 [Scope]
 AllowedCPUs=0-1
 </screen>
-   <screen>&prompt.root; cat /etc/systemd/system/system.slice.d/40-shielding.conf
+   <screen>&prompt.root;cat /etc/systemd/system/system.slice.d/40-shielding.conf
 [Slice]
 AllowedCPUs=0-1
 </screen>
@@ -53,16 +53,16 @@ AllowedCPUs=0-1
 <para>
         Finally, we create a dedicated slice for our sensitive workload with all the remaining system CPUs:
 </para>
-<screen>&prompt.root; cat /etc/systemd/system/workload.slice
+<screen>&prompt.root;cat /etc/systemd/system/workload.slice
 [Slice]
 AllowedCPUs=2-15
 </screen>
 <para>
         The setup can also be changed at runtime (for debugging reasons):
 </para>
-<screen>&prompt.root; systemctl set-property --runtime workload.slice AllowedCPUs=4-15
-&prompt.root; systemctl set-property --runtime init.scope AllowedCPUs=0-3
-&prompt.root; systemctl set-property --runtime system.slice AllowedCPUs=0-3
+<screen>&prompt.root;systemctl set-property --runtime workload.slice AllowedCPUs=4-15
+&prompt.root;systemctl set-property --runtime init.scope AllowedCPUs=0-3
+&prompt.root;systemctl set-property --runtime system.slice AllowedCPUs=0-3
 </screen>
  </sect1>
  <sect1 xml:id="sec-shielding-systemd-ex-move">
@@ -70,7 +70,7 @@ AllowedCPUs=2-15
     <para>
     When the <literal>workload.slice</literal> is prepared according to the previous section, running the sensitive jobs is as simple as configuring their service into that slice.
     </para>
-   <screen>&prompt.root; cat /etc/systemd/system/sensitive.service.d/40-shielding.conf
+   <screen>&prompt.root;cat /etc/systemd/system/sensitive.service.d/40-shielding.conf
 [Service]
 Slice=workload.slice
 </screen>
@@ -80,7 +80,7 @@ Slice=workload.slice
 <para>
         Should not the sensitive job have a form of a service but an ad-hoc command, you may start it in a systemd scope:
 </para>
-<screen>&prompt.root; systemd-run --scope -p Slice=workload.slice command arg1 ...</screen>
+<screen>&prompt.root;systemd-run --scope -p Slice=workload.slice command arg1 ...</screen>
 <note>
         <para>Existing processes cannot be moved under the shield since that would involve process migration between cgroups which would cause distortion of the accounting state.
         But sensitive workload should start with their resources secured in advance anyway.</para>

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+  %entities;
+]>
+
+<chapter version="5.0" xml:id="cha-shielding-model"
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>Shielding with systemd</title>
+ <info/>
+ <para>
+  systemd has native support for the cpuset controller since version 244.
+  Shielding the sensitive workload can be achieved by proper configuration of respective units.
+  This is only supported with cgroup unified hierarchy (v2) and hence the shielded
+  vs unshielded division copies the structure of typical systemd cgroup tree.
+ </para>
+
+ <sect1 xml:id="sec-systemd-shielding-teardown">
+   <title>Setup of the shield</title>
+   <para>
+        The general idea is to have one cpuset for the main sensitive workload
+        and a complementary cpuset for the supporting tasks.
+        Resources are distributed in the top-down fashion, so to ensure proper
+        allocation for the main workload we must take into consideration the
+        top-level cgroups on the system.
+        systemd by default creates the following units:
+           <literal>init.scope</literal>,
+           <literal>system.slice</literal>,
+           <literal>user.slice</literal> and
+           <literal>machine.slice</literal>.
+   </para>
+   <para>
+           We must configure <emphasis>all</emphasis> of these units not to stand in the way of our main workload.
+           For instance with following drop-in file(s): (TODO link to https://documentation.suse.com/sles/15-SP3/html/SLES-all/cha-systemd.html#sec-boot-systemd-custom-drop-in)
+   </para>
+   <screen>&prompt.root; cat /etc/systemd/system/init.scope.d/40-shielding.conf
+[Scope]
+AllowedCPUs=0-1
+</screen>
+   <screen>&prompt.root; cat /etc/systemd/system/system.slice.d/40-shielding.conf
+[Slice]
+AllowedCPUs=0-1
+</screen>
+...
+<para>
+        This way we constrain the system workload just to the first two CPUs.
+</para>
+<para>
+        Finally, we create a dedicated slice for our workload with all the remaining systemd CPUs:
+</para>
+<screen>&prompt.root; cat /etc/systemd/system/workload.slice
+[Slice]
+AllowedCPUs=2-15
+</screen>
+<para>
+        The setup can also be changed at runtime (for debugging reasons)
+</para>
+<screen>&prompt.root; systemctl set-property --runtime init.scope AllowedCPUs=0-1
+&prompt.root; systemctl set-property --runtime system.slice AllowedCPUs=0-1
+...
+</screen>
+ </sect1>
+ <sect1 xml:id="sec-shielding-systemd-ex-move">
+    <title>Running jobs in the shield</title>
+    <para>
+    When the <literal>workload.slice</literal> is prepared according to the previous section, running the sensitive jobs is as simple as configuring their service into that slice.
+    <para>
+   <screen>&prompt.root; cat /etc/systemd/system/sensitive.service.d/40-shielding.conf
+[Service]
+Slice=workload.slice
+</screen>
+<note>
+        Beware that the <literal>Slice=</literal> directive only takes effect upon service (re)start.
+</note>
+<para>
+        Should not the sensitive job have a form of a service but an ad-hoc command, you may start it in a systemd scope:
+</para>
+<screen>&prompt.root; systemd-run --scope -p Slice=workload.slice command arg1 ...</screen>
+<note>
+        Existing processes cannot be moved under the shield since that would involve process migration between cgroups which would cause distortion of the accounting state.
+        But sensitive workload should start with their resources ensured in advance anyway.
+</note>
+ </sect1>
+</chapter>


### PR DESCRIPTION
### Description

DocDay 2022 review of the shielding documentation. Changes are described in respective commits, the crux is slow preparation to move to cgroup v2.

Cc for the content: @JeffreyCheung  @fweisbec
For doc team: note I didn't build the XML, it may need some massaging before being buildable and following conventions again.

(`./xml/article_virtualization.xml` also uses `cset shield` with kthread migration but since rest of the text presents some qualitative observations related to that, I've kept that example untouched.)

### Are there any relevant issues/feature requests?

* jsc#PED-1447

### Which product versions do the changes apply to?

SLE-RT 15
- [x] 15 next *(current `main`, no backport necessary)*
- [ ] 15 SP4
- [ ] 15 SP3

SLE-RT 12
- [ ] 12 SP5

Might be applicable to 15 SP4 too, but I'd target rather only SP5 (i.e. no backports) where the v2 hierachy may be the default (subject of PED-1447).

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
