### PR TITLE
Fix bsc#1197305: Insert missing installation steps

### DIFF
--- a/xml/article_setup.xml
+++ b/xml/article_setup.xml
@@ -98,7 +98,7 @@
  <sect1 xml:id="sec-slert-quick-install">
   <title>Installing &slerte;</title>
   <para>
-   To install &slerte; &productnumber;, keep the following points in mind:
+   Keep the following points in mind:
   </para>
   <itemizedlist>
    <listitem>
@@ -123,6 +123,41 @@
     </para>
    </listitem>
   </itemizedlist>
+
+  <para>To install &slerte; &productnumber;, proceed as follows:</para>
+  <procedure>
+   <step>
+    <para>Start the normal &sle; &productnumber;.</para>
+   </step>
+   <step>
+    <para>On the boot command line, add <literal>start_shell=1</literal>.
+    </para>
+   </step>
+   <step>
+    <para>When the prompt shows up, open the file <filename>controlxml</filename> and add the
+    following lines:</para>
+    <screen>&lt;base_product>
+  &lt;display_name>SUSE Linux Enterprise Real Time &productnumber;&lt;/display_name>
+  &lt;name>SLE_RT&lt;/name>
+  &lt;version>15.4&lt;/version>
+  &lt;register_target>sle-15-$arch&lt;/register_target>
+  &lt;archs>x86_64&lt;/archs>
+&lt;/base_product></screen>
+   </step>
+   <step>
+    <para>Save the file, exit the editor, and restart &yast;</para>
+   </step>
+   <step>
+    <para>Select <guimenu>&productname; &productnumber;</guimenu> from the product selection list.
+    </para>
+   </step>
+   <step>
+    <para>Continue with the normal installation. The rest is the same of the other product installation.</para>
+   </step>
+   <step>
+    <para>Reboot and select the real time kernel.</para>
+   </step>
+  </procedure>
 
   <para>
    The following sections provide a brief introduction to the tools and


### PR DESCRIPTION
### Description

Add missing installation steps from mentioned Bugzilla (comment8).

@JeffreyCheung Could you look at it if something is missing? I wasn't completely sure if it was for SLE-RT 15SP4 or 15SP3 only. Maybe we need to adapt that.

Thank you!


### Are there any relevant issues/feature requests?

* [bsc#1197305](https://bugzilla.suse.com/show_bug.cgi?id=1197305): "Installing SUSE Linux Enterprise Real Time never tells you how to install it if you are offline"

### Which product versions do the changes apply to?

SLE-RT 15
- [x] 15 next *(current `main`, no backport necessary)*
- [x] 15 SP4
- [x] 15 SP3

SLE-RT 12
- [ ] ~12 SP5~

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
