### PR TITLE
links: http -> https

### DIFF
--- a/xml/article_setup.xml
+++ b/xml/article_setup.xml
@@ -1811,9 +1811,9 @@ noop deadline [cfq]</screen>
      The &cpuset; feature of the kernel is explained in
      <filename>/usr/src/linux/Documentation/cgroups/cpusets.txt</filename>.
      More detailed documentation is available from
-<!-- <link xlink:href="http://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi/linux/bks/SGI_Admin/books/LX_Resource_AG/sgi_html/ch01.html"
-	    />, <link xlink:href="http://www.bullopensource.org/cpuset/"/>, and -->
-     <link xlink:href="http://lwn.net/Articles/127936/"/>. -->
+<!-- <link xlink:href="https://techpubs.sgi.com/library/tpl/cgi-bin/getdoc.cgi/linux/bks/SGI_Admin/books/LX_Resource_AG/sgi_html/ch01.html"
+	    />, <link xlink:href="https://www.bullopensource.org/cpuset/"/>, and -->
+     <link xlink:href="https://lwn.net/Articles/127936/"/>. -->
     </para>
    </listitem>
 <!--
@@ -1832,7 +1832,7 @@ noop deadline [cfq]</screen>
     <para>
      For more information about the deadline I/O scheduler, refer to
      <link xlink:href="https://en.wikipedia.org/wiki/Deadline_scheduler"/>.
-<!-- <link xlink:href="http://kerneltrap.org/node/431"/> -->
+<!-- <link xlink:href="https://kerneltrap.org/node/431"/> -->
      In your installed system, find further information in
      <filename>/usr/src/linux/Documentation/block/deadline-iosched.txt</filename>.
     </para>
@@ -1840,7 +1840,7 @@ noop deadline [cfq]</screen>
    <listitem>
     <para>
      The CFQ I/O scheduler is covered in detail in
-     <link xlink:href="http://en.wikipedia.org/wiki/CFQ"/> and
+     <link xlink:href="https://en.wikipedia.org/wiki/CFQ"/> and
      <filename>/usr/src/linux/Documentation/block/cfq-iosched.txt</filename>.
     </para>
    </listitem>
@@ -1848,7 +1848,7 @@ noop deadline [cfq]</screen>
       <listitem>
         <para> A lot of information about real-time can be found at
             <link
-            xlink:href="http://linuxdevices.com/articles/AT6476691775.html"
+            xlink:href="https://linuxdevices.com/articles/AT6476691775.html"
           />. </para>
       </listitem>
       -->

--- a/xml/common_copyright_gfdl.xml
+++ b/xml/common_copyright_gfdl.xml
@@ -24,7 +24,7 @@
  </para>
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All other
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All other
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (*) denote third-party trademarks.

--- a/xml/common_copyright_quick.xml
+++ b/xml/common_copyright_quick.xml
@@ -22,7 +22,7 @@
 
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All other
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All other
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (*) denote third-party trademarks.

--- a/xml/common_gfdl1.2_i.xml
+++ b/xml/common_gfdl1.2_i.xml
@@ -494,7 +494,7 @@
   Free Documentation License from time to time. Such new versions will be
   similar in spirit to the present version, but may differ in detail to
   address new problems or concerns. See
-  <link xlink:href="http://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
+  <link xlink:href="https://www.gnu.org/copyleft/">http://www.gnu.org/copyleft/</link>.
  </para>
 
  <para>


### PR DESCRIPTION
### Description

Fix broken links and replace `http` by `https` protocol where feasible.

### Are there any relevant issues/feature requests?

- see also https://github.com/SUSE/doc-sle/pull/1635 

### Which product versions do the changes apply to?

SLE-RT 15
- [x] 15 next *(current `main`, no backport necessary)*
- [x] 15 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
