### PR TITLE
Revision History: initial entry for FCS of 15 SP7 

### DIFF
--- a/xml/article_hardware_testing.xml
+++ b/xml/article_hardware_testing.xml
@@ -26,7 +26,7 @@
   </meta>
   <revhistory xml:id="rh-article-hardware-testing">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/article_setup.xml
+++ b/xml/article_setup.xml
@@ -27,7 +27,7 @@
   </meta>
   <revhistory xml:id="rh-article-setup">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/article_virtualization.xml
+++ b/xml/article_virtualization.xml
@@ -27,7 +27,7 @@
   </meta>
   <revhistory xml:id="rh-article-virtualization">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_slert_shielding.xml
+++ b/xml/book_slert_shielding.xml
@@ -27,7 +27,7 @@
     </meta>
     <revhistory xml:id="rh-book-shielding">
       <revision>
-        <date>2024-06-26</date>
+        <date>2025-06-17</date>
         <revdescription>
           <para>
             Updated for the initial release of &productname; &productnumber;.


### PR DESCRIPTION
### Description

Set date in revision history to FCS date for 15 SP7 and keep initial entry as agreed with @lvicoun.


### Which product versions do the changes apply to?

SLE-RT 15
- [x] 15 next *(current `main`, no backport necessary)*
