### PR TITLE
Metadata generation jcayouette

### DIFF
--- a/report-meta-descriptions.html
+++ b/report-meta-descriptions.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en" class="bg-slate-100">
+<head>
+  <meta charset="UTF-8">
+  <title>SLES RT Meta Descriptions: AI Generated Meta Descriptions</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans text-slate-800">
+<div class="container mx-auto p-4 sm:p-6 lg:p-8">
+
+  <div class="mb-8">
+    <h1 class="text-4xl font-bold text-slate-900">SLES RT Meta Descriptions</h1>
+    <p class="text-xl text-slate-600 mt-1">AI Generated Meta Descriptions</p>
+    <p class="text-sm text-slate-400 mt-2">Report generated on 2026-04-29 11:03:26</p>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+    <div class="bg-white p-5 rounded-xl shadow-lg flex items-center justify-between">
+      <div><div class="text-sm font-medium text-slate-500">Files Processed</div><div class="mt-1 text-3xl font-semibold text-slate-900">7</div></div>
+    </div>
+    <div class="bg-white p-5 rounded-xl shadow-lg flex items-center justify-between">
+      <div><div class="text-sm font-medium text-slate-500">Files Changed</div><div class="mt-1 text-3xl font-semibold text-green-600">6</div></div>
+    </div>
+    <div class="bg-white p-5 rounded-xl shadow-lg flex items-center justify-between">
+      <div><div class="text-sm font-medium text-slate-500">Processing Time</div><div class="mt-1 text-3xl font-semibold text-slate-900">106.22s</div></div>
+    </div>
+    <div class="bg-white p-5 rounded-xl shadow-lg flex items-center justify-between">
+      <div><div class="text-sm font-medium text-slate-500">Model Used</div><div class="mt-1 text-2xl font-semibold text-slate-900 truncate">qwen3:14b</div></div>
+    </div>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-lg overflow-hidden">
+    <div class="p-5 border-b border-slate-200 flex flex-col sm:flex-row justify-between items-center">
+      <div>
+        <h2 class="text-xl font-semibold text-slate-900">Processing Log</h2>
+        <p class="text-sm text-slate-500 mt-1">Detailed log of all file operations.</p>
+      </div>
+      <input type="text" id="searchInput" onkeyup="filterTable()" placeholder="Filter by path, status, or details..."
+        class="mt-4 sm:mt-0 w-full sm:w-64 px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500">
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full" id="logTable">
+        <thead class="bg-slate-100 text-slate-600 text-sm font-semibold uppercase">
+          <tr>
+            <th class="py-3 px-6 text-left">File</th>
+            <th class="py-3 px-6 text-left">Type</th>
+            <th class="py-3 px-6 text-left">Status</th>
+            <th class="py-3 px-6 text-left">Chars</th>
+            <th class="py-3 px-6 text-left">Description / Details</th>
+          </tr>
+        </thead>
+        <tbody class="text-sm">
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-yellow-500" title="xml/common_legal.xml">xml/common_legal.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-yellow-500">WARNING</span></td>
+            <td class="py-3 px-6 text-slate-500"></td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Insufficient content for generation (108 chars, minimum 150)</td>
+          </tr>
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_cpuset_manipulation.xml">xml/slert_cpuset_manipulation.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6 text-slate-500">124</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Manipulate cpusets using csets set and proc subcommands to create, adjust, rename, destroy, and manage processes within them</td>
+          </tr>
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_gettinghelp.xml">xml/slert_gettinghelp.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6 text-slate-500">160</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Discover how to use the csets logging application on supported systems to diagnose and resolve issues by creating logs with the --log option and submitting them</td>
+          </tr>
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_intro.xml">xml/slert_intro.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6 text-slate-500">156</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn how to use the cset command-line tool to manage cpusets, configure CPU and memory placement, and implement shielding and advanced resource constraints</td>
+          </tr>
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_shielding_model.xml">xml/slert_shielding_model.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6 text-slate-500">119</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn how to use the shield subcommand to configure and manage CPU sets for task isolation and performance optimization</td>
+          </tr>
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_systemd_shielding.xml">xml/slert_systemd_shielding.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6 text-slate-500">153</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Explore how to configure systemd's cpuset controller to shield sensitive workloads by setting up dedicated slices configuring system.slice and init.slice</td>
+          </tr>
+          <tr class="border-b border-slate-200 hover:bg-slate-50">
+            <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_usingshortcuts.xml">xml/slert_usingshortcuts.xml</td>
+            <td class="py-3 px-6 whitespace-nowrap">docbook</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6 text-slate-500">145</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn to use shortcuts in cset commands to execute subcommands and options with fewer characters while maintaining clarity and intuitive outcomes</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="mt-8 text-center text-sm text-slate-500">
+    <p>Root: xml &bull; Type filter: docbook</p>
+  </div>
+</div>
+<script>
+function filterTable() {
+  var input = document.getElementById("searchInput").value.toUpperCase();
+  var rows = document.getElementById("logTable").getElementsByTagName("tr");
+  for (var i = 1; i < rows.length; i++) {
+    var cells = rows[i].getElementsByTagName("td");
+    var match = false;
+    for (var j = 0; j < cells.length; j++) {
+      if ((cells[j].textContent || cells[j].innerText).toUpperCase().indexOf(input) > -1) {
+        match = true; break;
+      }
+    }
+    rows[i].style.display = match ? "" : "none";
+  }
+}
+</script>
+</body>
+</html>

--- a/report-meta-descriptions.html
+++ b/report-meta-descriptions.html
@@ -11,7 +11,7 @@
   <div class="mb-8">
     <h1 class="text-4xl font-bold text-slate-900">SLES RT Meta Descriptions</h1>
     <p class="text-xl text-slate-600 mt-1">AI Generated Meta Descriptions</p>
-    <p class="text-sm text-slate-400 mt-2">Report generated on 2026-04-29 11:03:26</p>
+    <p class="text-sm text-slate-400 mt-2">Report generated on 2026-08-14 12:23:02</p>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
@@ -22,7 +22,7 @@
       <div><div class="text-sm font-medium text-slate-500">Files Changed</div><div class="mt-1 text-3xl font-semibold text-green-600">6</div></div>
     </div>
     <div class="bg-white p-5 rounded-xl shadow-lg flex items-center justify-between">
-      <div><div class="text-sm font-medium text-slate-500">Processing Time</div><div class="mt-1 text-3xl font-semibold text-slate-900">106.22s</div></div>
+      <div><div class="text-sm font-medium text-slate-500">Processing Time</div><div class="mt-1 text-3xl font-semibold text-slate-900">95.20s</div></div>
     </div>
     <div class="bg-white p-5 rounded-xl shadow-lg flex items-center justify-between">
       <div><div class="text-sm font-medium text-slate-500">Model Used</div><div class="mt-1 text-2xl font-semibold text-slate-900 truncate">qwen3:14b</div></div>
@@ -60,44 +60,44 @@
           <tr class="border-b border-slate-200 hover:bg-slate-50">
             <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_cpuset_manipulation.xml">xml/slert_cpuset_manipulation.xml</td>
             <td class="py-3 px-6 whitespace-nowrap">docbook</td>
-            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">REPLACED</span></td>
             <td class="py-3 px-6 text-slate-500">124</td>
             <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Manipulate cpusets using csets set and proc subcommands to create, adjust, rename, destroy, and manage processes within them</td>
           </tr>
           <tr class="border-b border-slate-200 hover:bg-slate-50">
             <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_gettinghelp.xml">xml/slert_gettinghelp.xml</td>
             <td class="py-3 px-6 whitespace-nowrap">docbook</td>
-            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">REPLACED</span></td>
             <td class="py-3 px-6 text-slate-500">160</td>
-            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Discover how to use the csets logging application on supported systems to diagnose and resolve issues by creating logs with the --log option and submitting them</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Use the csets logging application to create logs with the --log option and submit them to Bugzilla for diagnosing and resolving issues on supported SUSE systems</td>
           </tr>
           <tr class="border-b border-slate-200 hover:bg-slate-50">
             <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_intro.xml">xml/slert_intro.xml</td>
             <td class="py-3 px-6 whitespace-nowrap">docbook</td>
-            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
-            <td class="py-3 px-6 text-slate-500">156</td>
-            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn how to use the cset command-line tool to manage cpusets, configure CPU and memory placement, and implement shielding and advanced resource constraints</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">REPLACED</span></td>
+            <td class="py-3 px-6 text-slate-500">152</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn to use the cset command-line tool to manage cpusets, configure CPU and memory placement, and implement shielding and advanced resource constraints</td>
           </tr>
           <tr class="border-b border-slate-200 hover:bg-slate-50">
             <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_shielding_model.xml">xml/slert_shielding_model.xml</td>
             <td class="py-3 px-6 whitespace-nowrap">docbook</td>
-            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
-            <td class="py-3 px-6 text-slate-500">119</td>
-            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn how to use the shield subcommand to configure and manage CPU sets for task isolation and performance optimization</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">REPLACED</span></td>
+            <td class="py-3 px-6 text-slate-500">115</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn to use the shield subcommand to configure and manage CPU sets for task isolation and performance optimization</td>
           </tr>
           <tr class="border-b border-slate-200 hover:bg-slate-50">
             <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_systemd_shielding.xml">xml/slert_systemd_shielding.xml</td>
             <td class="py-3 px-6 whitespace-nowrap">docbook</td>
-            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
-            <td class="py-3 px-6 text-slate-500">153</td>
-            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Explore how to configure systemd's cpuset controller to shield sensitive workloads by setting up dedicated slices configuring system.slice and init.slice</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">REPLACED</span></td>
+            <td class="py-3 px-6 text-slate-500">130</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Configure systemd's cpuset controller to shield sensitive workloads by setting up dedicated slices for system.slice and init.slice</td>
           </tr>
           <tr class="border-b border-slate-200 hover:bg-slate-50">
             <td class="py-3 px-6 font-medium text-slate-700 border-l-4 border-green-500" title="xml/slert_usingshortcuts.xml">xml/slert_usingshortcuts.xml</td>
             <td class="py-3 px-6 whitespace-nowrap">docbook</td>
-            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">ADDED</span></td>
-            <td class="py-3 px-6 text-slate-500">145</td>
-            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn to use shortcuts in cset commands to execute subcommands and options with fewer characters while maintaining clarity and intuitive outcomes</td>
+            <td class="py-3 px-6"><span class="text-white text-xs font-bold px-2.5 py-1 rounded-full bg-green-500">REPLACED</span></td>
+            <td class="py-3 px-6 text-slate-500">122</td>
+            <td class="py-3 px-6 font-mono text-xs text-slate-600 break-words">Learn to use shortcuts in cset commands to execute subcommands and options with fewer characters while maintaining clarity</td>
           </tr>
         </tbody>
       </table>

--- a/xml/slert_cpuset_manipulation.xml
+++ b/xml/slert_cpuset_manipulation.xml
@@ -4,9 +4,10 @@
   %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-cpuset">
+<chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-cpuset">
  <title>Full-featured cpuset manipulation commands</title>
- <info xmlns:d="http://docbook.org/ns/docbook"><revhistory xml:id="rh-cha-shielding-cpuset">
+ <info>
+    <meta name="description" its:translate="yes">Manipulate cpusets using csets set and proc subcommands to create, adjust, rename, destroy, and manage processes within them</meta><revhistory xml:id="rh-cha-shielding-cpuset">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_gettinghelp.xml
+++ b/xml/slert_gettinghelp.xml
@@ -4,9 +4,10 @@
   %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shieldingt-help">
+<chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shieldingt-help">
  <title>What to do if there are problems</title>
- <info xmlns:d="http://docbook.org/ns/docbook"><revhistory xml:id="rh-cha-shieldingt-help">
+ <info>
+    <meta name="description" its:translate="yes">Discover how to use the csets logging application on supported systems to diagnose and resolve issues by creating logs with the --log option and submitting them</meta><revhistory xml:id="rh-cha-shieldingt-help">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_gettinghelp.xml
+++ b/xml/slert_gettinghelp.xml
@@ -7,7 +7,7 @@
 <chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shieldingt-help">
  <title>What to do if there are problems</title>
  <info>
-    <meta name="description" its:translate="yes">Discover how to use the csets logging application on supported systems to diagnose and resolve issues by creating logs with the --log option and submitting them</meta><revhistory xml:id="rh-cha-shieldingt-help">
+    <meta name="description" its:translate="yes">Use the csets logging application to create logs with the --log option and submit them to Bugzilla for diagnosing and resolving issues on supported SUSE systems</meta><revhistory xml:id="rh-cha-shieldingt-help">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_intro.xml
+++ b/xml/slert_intro.xml
@@ -4,9 +4,10 @@
   %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-intro">
+<chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-intro">
  <title>Introduction</title>
- <info xmlns:d="http://docbook.org/ns/docbook"><revhistory xml:id="rh-cha-shielding-intro">
+ <info>
+    <meta name="description" its:translate="yes">Learn how to use the cset command-line tool to manage cpusets, configure CPU and memory placement, and implement shielding and advanced resource constraints</meta><revhistory xml:id="rh-cha-shielding-intro">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_intro.xml
+++ b/xml/slert_intro.xml
@@ -7,7 +7,7 @@
 <chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-intro">
  <title>Introduction</title>
  <info>
-    <meta name="description" its:translate="yes">Learn how to use the cset command-line tool to manage cpusets, configure CPU and memory placement, and implement shielding and advanced resource constraints</meta><revhistory xml:id="rh-cha-shielding-intro">
+    <meta name="description" its:translate="yes">Learn to use the cset command-line tool to manage cpusets, configure CPU and memory placement, and implement shielding and advanced resource constraints</meta><revhistory xml:id="rh-cha-shielding-intro">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_shielding_model.xml
+++ b/xml/slert_shielding_model.xml
@@ -4,9 +4,10 @@
   %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-model">
+<chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-model">
  <title>The basic shielding model</title>
- <info xmlns:d="http://docbook.org/ns/docbook"><revhistory xml:id="rh-cha-shielding-model">
+ <info>
+    <meta name="description" its:translate="yes">Learn how to use the shield subcommand to configure and manage CPU sets for task isolation and performance optimization</meta><revhistory xml:id="rh-cha-shielding-model">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_shielding_model.xml
+++ b/xml/slert_shielding_model.xml
@@ -7,7 +7,7 @@
 <chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-model">
  <title>The basic shielding model</title>
  <info>
-    <meta name="description" its:translate="yes">Learn how to use the shield subcommand to configure and manage CPU sets for task isolation and performance optimization</meta><revhistory xml:id="rh-cha-shielding-model">
+    <meta name="description" its:translate="yes">Learn to use the shield subcommand to configure and manage CPU sets for task isolation and performance optimization</meta><revhistory xml:id="rh-cha-shielding-model">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -4,9 +4,10 @@
   %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-with-systemd">
+<chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-with-systemd">
 <title>Shielding with systemd</title>
- <info xmlns:d="http://docbook.org/ns/docbook"><revhistory xml:id="rh-cha-shielding-with-systemd">
+ <info>
+    <meta name="description" its:translate="yes">Explore how to configure systemd's cpuset controller to shield sensitive workloads by setting up dedicated slices configuring system.slice and init.slice</meta><revhistory xml:id="rh-cha-shielding-with-systemd">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_systemd_shielding.xml
+++ b/xml/slert_systemd_shielding.xml
@@ -7,7 +7,7 @@
 <chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-with-systemd">
 <title>Shielding with systemd</title>
  <info>
-    <meta name="description" its:translate="yes">Explore how to configure systemd's cpuset controller to shield sensitive workloads by setting up dedicated slices configuring system.slice and init.slice</meta><revhistory xml:id="rh-cha-shielding-with-systemd">
+    <meta name="description" its:translate="yes">Configure systemd's cpuset controller to shield sensitive workloads by setting up dedicated slices for system.slice and init.slice</meta><revhistory xml:id="rh-cha-shielding-with-systemd">
    <revision>
      <date>2022-11-25</date>
      <revdescription>

--- a/xml/slert_usingshortcuts.xml
+++ b/xml/slert_usingshortcuts.xml
@@ -4,9 +4,10 @@
   %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-shortcuts">
+<chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-shortcuts">
  <title>Using shortcuts</title>
- <info xmlns:d="http://docbook.org/ns/docbook"><revhistory xml:id="rh-cha-shielding-shortcuts">
+ <info>
+    <meta name="description" its:translate="yes">Learn to use shortcuts in cset commands to execute subcommands and options with fewer characters while maintaining clarity and intuitive outcomes</meta><revhistory xml:id="rh-cha-shielding-shortcuts">
    <revision>
      <date>2022-01-17</date>
      <revdescription>

--- a/xml/slert_usingshortcuts.xml
+++ b/xml/slert_usingshortcuts.xml
@@ -7,7 +7,7 @@
 <chapter xmlns:its="http://www.w3.org/2005/11/its" xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-shielding-shortcuts">
  <title>Using shortcuts</title>
  <info>
-    <meta name="description" its:translate="yes">Learn to use shortcuts in cset commands to execute subcommands and options with fewer characters while maintaining clarity and intuitive outcomes</meta><revhistory xml:id="rh-cha-shielding-shortcuts">
+    <meta name="description" its:translate="yes">Learn to use shortcuts in cset commands to execute subcommands and options with fewer characters while maintaining clarity</meta><revhistory xml:id="rh-cha-shielding-shortcuts">
    <revision>
      <date>2022-01-17</date>
      <revdescription>


### PR DESCRIPTION
### Description

This PR adds meta descriptions for doc-slert main.

meta descriptions for files of the following DOCTYPE:

- `<!DOCTYPE appendix`
- `<!DOCTYPE chapter`
- `<!DOCTYPE preface`

The following doctypes were skipped:
```
<!DOCTYPE sect1
<!DOCTYPE sect2 
<!DOCTYPE sect3 
<!DOCTYPE sect4 
<!DOCTYPE sect5 
<!DOCTYPE book 
<!DOCTYPE article 
<!DOCTYPE set 
```

Placing of meta descriptions and 'its' namespace
```
# Placed inside the <info> element. 

<meta name="description" its:translate="yes">...</meta>  
```
Added the namespace: 
```
xmlns:its="http://www.w3.org/2005/11/its"
```

See the meta description html report in project root for detailed changes